### PR TITLE
[CP-26] chore: jacoco 연동 해제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ sonarqube {
         property "sonar.projectKey", "prgrms-web-devcourse_Team_i6_comepet_BE"
         property "sonar.organization", "prgrms-web-devcourse"
         property "sonar.host.url", "https://sonarcloud.io"
-        property 'sonar.coverage.jacoco.xmlReportPaths', "$buildDir/jacoco.xml"
+//        property 'sonar.coverage.jacoco.xmlReportPaths', "$buildDir/jacoco.xml"
     }
 }
 


### PR DESCRIPTION
## PR 종류

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [x] Chore
- [ ] Init 

close #26 

## 내용
- 설명 : 소나 클라우드 퀄리티 게이트 이슈로 인한 임시 연동 해제

## 추가 및 변경 로직
- 그레이들에 자코코 프로퍼티 삭제

## 참고 및 기타
