### PR TITLE
[CP-82] fix: 몸무게 필드 long에서 double로 수정

### DIFF
--- a/src/main/java/com/pet/domains/post/domain/ShelterPost.java
+++ b/src/main/java/com/pet/domains/post/domain/ShelterPost.java
@@ -83,8 +83,8 @@ public class ShelterPost extends BaseEntity {
     @Column(name = "feature", length = 200, nullable = false)
     private String feature;
 
-    @Column(name = "weight", columnDefinition = "LONG default 0", scale = 2, nullable = false)
-    private long weight;
+    @Column(name = "weight", columnDefinition = "DOUBLE default 0", nullable = false)
+    private Double weight;
 
     @Column(name = "notice_number", length = 30, nullable = false)
     private String noticeNumber;


### PR DESCRIPTION
## PR 종류

- [ ] Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #82 

## 내용
- 설명 : 보호소 동물 게시글 몸무게 필드 이슈 수정

## 추가 및 변경 로직
- 몸무게 필드 long에서 double로 수정

## 참고 및 기타
