### PR TITLE
[CP-96] feat: S3 이미지 업로드 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/pet/common/s3/controller/FileUploadController.java
+++ b/src/main/java/com/pet/common/s3/controller/FileUploadController.java
@@ -1,0 +1,23 @@
+package com.pet.common.s3.controller;
+
+import com.pet.common.s3.service.FileUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/upload")
+@RestController
+public class FileUploadController {
+
+    private final FileUploadService fileUploadService;
+
+    @PostMapping()
+    public String uploadImage(@RequestParam MultipartFile file) {
+        return fileUploadService.uploadImage(file);
+    }
+
+}

--- a/src/main/java/com/pet/common/s3/service/FileUploadService.java
+++ b/src/main/java/com/pet/common/s3/service/FileUploadService.java
@@ -1,0 +1,44 @@
+package com.pet.common.s3.service;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.MessageFormat;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+public class FileUploadService {
+
+    private final UploadService uploadService;
+
+    public String uploadImage(MultipartFile file) {
+        String fileName = createFileName(file.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+        try (InputStream inputStream = file.getInputStream()) {
+            uploadService.uploadFile(inputStream, objectMetadata, fileName);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                MessageFormat.format("{0} 파일 변환 중 에러가 발생했습니다.", file.getOriginalFilename()));
+        }
+        return uploadService.getFileUrl(fileName);
+    }
+
+    private String createFileName(String originalFileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(originalFileName));
+    }
+
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(MessageFormat.format("잘못된 형식의 {0} 파일 입니다.", fileName));
+        }
+    }
+
+}

--- a/src/main/java/com/pet/common/s3/service/S3UploadService.java
+++ b/src/main/java/com/pet/common/s3/service/S3UploadService.java
@@ -1,0 +1,33 @@
+package com.pet.common.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class S3UploadService implements UploadService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public void uploadFile(InputStream inputStream, ObjectMetadata objectMetadata, String fileName) {
+        amazonS3Client.putObject(
+            new PutObjectRequest(bucket, fileName, inputStream, objectMetadata).withCannedAcl(
+                CannedAccessControlList.PublicRead));
+    }
+
+    @Override
+    public String getFileUrl(String fileName) {
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+}

--- a/src/main/java/com/pet/common/s3/service/UploadService.java
+++ b/src/main/java/com/pet/common/s3/service/UploadService.java
@@ -1,0 +1,12 @@
+package com.pet.common.s3.service;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.InputStream;
+
+public interface UploadService {
+
+    void uploadFile(InputStream inputStream, ObjectMetadata objectMetadata, String fileName);
+
+    String getFileUrl(String fileName);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,8 @@ cloud:
     stack:
       auto: false
     credentials:
+      accessKey: ${S3_ACCESS_KEY:empty}
+      secretKey: ${S3_SECRET_KEY:empty}
       instance-profile: true
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     hibernate:
       ddl-auto: create-drop
     open-in-view: false
+  servlet:
+    multipart:
+      max-file-size: 5MB
+      max-request-size: 5MB
 server:
   servlet:
     encoding:
@@ -19,3 +23,23 @@ compet:
     api:
       name: shelter
       key: ${SHELTER_API_KEY}
+
+cloud:
+  aws:
+    s3:
+      bucket: compet-dev-image
+    region:
+      auto: false
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${S3_ACCESS_KEY}
+      secretKey: ${S3_SECRET_KEY}
+
+logging:
+  level:
+    com:
+      amazonaws:
+        util:
+          EC2MetadataUtils: error

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,8 +34,7 @@ cloud:
     stack:
       auto: false
     credentials:
-      accessKey: ${S3_ACCESS_KEY}
-      secretKey: ${S3_SECRET_KEY}
+      instance-profile: true
 
 logging:
   level:


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #96 

## 내용
- 설명 : 이미지 업로드 관련 코드 추가.
- `build.gradle` : aws 의존성 추가
- `application.yml` : 파일 최대 업로드 크기, IAM 키, 필요 설정 추가
- `FileUploaderController` : 이미지 업로드 API 컨트롤러
- `FileUploadService` : Multipart로 전송받은 파일을 UUID + 확장자명 이름으로 업로드
- `S3UploadService` : S3에 업로드

## 추가 및 변경 로직
- change

## 참고 및 기타
