### PR TITLE
[CP-122] feat: 동물,품종 api 데이터 서비스 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation 'com.auth0:java-jwt:3.18.2'
 //    implementation 'org.springframework.boo t:spring-boot-starter-oauth2-client'
 //    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
     implementation 'org.apache.commons:commons-lang3:3.12.0'
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -65,9 +65,6 @@ include::{snippets}/common/custom-response-fields-status.adoc[]
 [[sexType]]
 include::{snippets}/common/custom-response-fields-sexTypes.adoc[]
 
-[[shelterSexType]]
-include::{snippets}/common/custom-response-fields-shelterSexTypes.adoc[]
-
 [[neuteredType]]
 include::{snippets}/common/custom-response-fields-neuteredTypes.adoc[]
 

--- a/src/main/java/com/pet/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/pet/common/exception/ExceptionMessage.java
@@ -18,6 +18,8 @@ public enum ExceptionMessage {
     NOT_FOUND_ACCOUNT(new BadRequestException("해당하는 유저를 찾을 수 없습니다.")),
 
     // 동물
+    NOT_FOUND_ANIMAL(new BadRequestException("해당하는 동물 종류를 찾을 수 없습니다.")),
+
 
     // 지역
 

--- a/src/main/java/com/pet/common/property/ShelterProperties.java
+++ b/src/main/java/com/pet/common/property/ShelterProperties.java
@@ -25,4 +25,12 @@ public class ShelterProperties {
         private final String key;
     }
 
+    public String getUrl() {
+        return api.getUrl();
+    }
+
+    public String getKey() {
+        return api.getKey();
+    }
+
 }

--- a/src/main/java/com/pet/domains/animal/domain/Animal.java
+++ b/src/main/java/com/pet/domains/animal/domain/Animal.java
@@ -8,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -27,4 +28,9 @@ public class Animal extends BaseEntity {
     @Column(name = "code", length = 30, nullable = false)
     private String code;
 
+    @Builder
+    public Animal(String name, String code) {
+        this.name = name;
+        this.code = code;
+    }
 }

--- a/src/main/java/com/pet/domains/animal/domain/AnimalKind.java
+++ b/src/main/java/com/pet/domains/animal/domain/AnimalKind.java
@@ -12,6 +12,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,7 +30,7 @@ public class AnimalKind extends BaseEntity {
     @Column(name = "name", length = 50, nullable = false)
     private String name;
 
-    @Column(name = "code", length = 6, nullable = false)
+    @Column(name = "code", length = 6)
     private String code;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -41,4 +42,10 @@ public class AnimalKind extends BaseEntity {
     )
     private Animal animal;
 
+    @Builder
+    public AnimalKind(String name, String code, Animal animal) {
+        this.name = name;
+        this.code = code;
+        this.animal = animal;
+    }
 }

--- a/src/main/java/com/pet/domains/animal/dto/request/AnimalKindCreateParams.java
+++ b/src/main/java/com/pet/domains/animal/dto/request/AnimalKindCreateParams.java
@@ -1,0 +1,30 @@
+package com.pet.domains.animal.dto.request;
+
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+
+
+@Getter
+@XmlRootElement(name = "items")
+@XmlAccessorType(XmlAccessType.NONE)
+public class AnimalKindCreateParams {
+
+    @XmlElement(name = "item")
+    private List<AnimalKindCreateParams.AnimalKind> animalKinds;
+
+    @Getter
+    @XmlRootElement(name = "item")
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class AnimalKind {
+
+        @XmlElement(name = "KNm")
+        private String name;
+
+        @XmlElement(name = "kindCd")
+        private String code;
+    }
+}

--- a/src/main/java/com/pet/domains/animal/dto/response/AnimalKindApiPageResults.java
+++ b/src/main/java/com/pet/domains/animal/dto/response/AnimalKindApiPageResults.java
@@ -1,0 +1,31 @@
+package com.pet.domains.animal.dto.response;
+
+import com.pet.domains.animal.dto.request.AnimalKindCreateParams;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+
+@Getter
+@XmlRootElement(name = "response")
+@XmlAccessorType(XmlAccessType.NONE)
+public class AnimalKindApiPageResults {
+
+    @XmlElement(name = "body")
+    private AnimalKindApiPageResults.Body body;
+
+    @Getter
+    @XmlRootElement(name = "body")
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class Body {
+
+        @XmlElement(name = "items")
+        private AnimalKindCreateParams items;
+
+    }
+
+    public AnimalKindCreateParams getBodyItems() {
+        return body.getItems();
+    }
+}

--- a/src/main/java/com/pet/domains/animal/repository/AnimalKindRepository.java
+++ b/src/main/java/com/pet/domains/animal/repository/AnimalKindRepository.java
@@ -1,0 +1,11 @@
+package com.pet.domains.animal.repository;
+
+import com.pet.domains.animal.domain.AnimalKind;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimalKindRepository extends JpaRepository<AnimalKind, Long> {
+
+    Optional<AnimalKind> findByName(String name);
+
+}

--- a/src/main/java/com/pet/domains/animal/repository/AnimalRepository.java
+++ b/src/main/java/com/pet/domains/animal/repository/AnimalRepository.java
@@ -1,0 +1,11 @@
+package com.pet.domains.animal.repository;
+
+import com.pet.domains.animal.domain.Animal;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnimalRepository extends JpaRepository<Animal, Long> {
+
+    Optional<Animal> findByCode(String code);
+
+}

--- a/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
+++ b/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
@@ -26,16 +26,12 @@ public class AnimalKindService {
     private final AnimalRepository animalRepository;
 
     public void createAnimalKinds(String animalCode, AnimalKindCreateParams animalKindCreateParams) {
-
-        Animal foundAnimal = animalRepository.findByCode(animalCode)
-            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
-
         Set<AnimalKind> transactionChunk = new HashSet<>();
         animalKindCreateParams.getAnimalKinds().forEach(animalKindCreateParam -> {
                 transactionChunk.add(AnimalKind.builder()
                     .name(animalKindCreateParam.getName())
                     .code(animalKindCreateParam.getCode())
-                    .animal(foundAnimal)
+                    .animal(getAnimalByCode(animalCode))
                     .build()
                 );
                 if (transactionChunk.size() == TRANSACTION_CHUNK_LIMIT) {
@@ -50,17 +46,23 @@ public class AnimalKindService {
 
     @Transactional
     public AnimalKind getOrCreateByAnimalKind(Long animalId, String animalKindName) {
-
-        Animal foundAnimal = animalRepository.findById(animalId)
-            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
-
         return animalKindRepository.findByName(animalKindName)
             .orElseGet(() -> animalKindRepository.save(
                 AnimalKind.builder()
-                    .animal(foundAnimal)
+                    .animal(getAnimalById(animalId))
                     .name(animalKindName)
                     .build()
             ));
+    }
+
+    private Animal getAnimalByCode(String animalCode) {
+        return animalRepository.findByCode(animalCode)
+            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
+    }
+
+    private Animal getAnimalById(Long animalId) {
+        return animalRepository.findById(animalId)
+            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
     }
 
 }

--- a/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
+++ b/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
@@ -1,0 +1,66 @@
+package com.pet.domains.animal.service;
+
+
+import com.pet.common.exception.ExceptionMessage;
+import com.pet.domains.animal.domain.Animal;
+import com.pet.domains.animal.domain.AnimalKind;
+import com.pet.domains.animal.dto.request.AnimalKindCreateParams;
+import com.pet.domains.animal.repository.AnimalKindRepository;
+import com.pet.domains.animal.repository.AnimalRepository;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AnimalKindService {
+
+    private static final int TRANSACTION_CHUNK_LIMIT = 100;
+
+    private final AnimalKindRepository animalKindRepository;
+
+    private final AnimalRepository animalRepository;
+
+    public void createAnimalKinds(String animalCode, AnimalKindCreateParams animalKindCreateParams) {
+
+        Animal foundAnimal = animalRepository.findByCode(animalCode)
+            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
+
+        Set<AnimalKind> transactionChunk = new HashSet<>();
+        animalKindCreateParams.getAnimalKinds().forEach(animalKindCreateParam -> {
+                transactionChunk.add(AnimalKind.builder()
+                    .name(animalKindCreateParam.getName())
+                    .code(animalKindCreateParam.getCode())
+                    .animal(foundAnimal)
+                    .build()
+                );
+                if (transactionChunk.size() == TRANSACTION_CHUNK_LIMIT) {
+                    animalKindRepository.saveAll(transactionChunk);
+                    transactionChunk.clear();
+                    log.info("AnimalKind set has saved with chunk unit");
+                }
+            }
+        );
+        animalKindRepository.saveAll(transactionChunk);
+    }
+
+    @Transactional
+    public AnimalKind getOrCreateByAnimalKind(Long animalId, String animalKindName) {
+
+        Animal foundAnimal = animalRepository.findById(animalId)
+            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
+
+        return animalKindRepository.findByName(animalKindName)
+            .orElseGet(() -> animalKindRepository.save(
+                AnimalKind.builder()
+                    .animal(foundAnimal)
+                    .name(animalKindName)
+                    .build()
+            ));
+    }
+
+}

--- a/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
+++ b/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
@@ -13,10 +13,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
-@ToString
 @Getter
 @XmlRootElement(name = "items")
 @XmlAccessorType(XmlAccessType.NONE)
@@ -25,7 +23,6 @@ public class ShelterPostCreateParams {
     @XmlElement(name = "item")
     private List<ShelterPostCreateParams.ShelterPost> shelterPosts;
 
-    @ToString
     @Getter
     @XmlRootElement(name = "item")
     @XmlAccessorType(XmlAccessType.NONE)

--- a/src/main/java/com/pet/domains/post/dto/response/ShelterApiPageResult.java
+++ b/src/main/java/com/pet/domains/post/dto/response/ShelterApiPageResult.java
@@ -33,5 +33,4 @@ public class ShelterApiPageResult {
         @XmlElement(name = "items")
         private ShelterPostCreateParams items;
     }
-
 }

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -1,31 +1,56 @@
 package com.pet.domains.post.service;
 
 import com.pet.common.property.ShelterProperties;
-import com.pet.common.property.ShelterProperties.Api;
+import com.pet.domains.animal.dto.request.AnimalKindCreateParams;
+import com.pet.domains.animal.dto.response.AnimalKindApiPageResults;
+import com.pet.domains.animal.service.AnimalKindService;
+import com.pet.domains.post.dto.request.ShelterPostCreateParams;
 import com.pet.domains.post.dto.response.ShelterApiPageResult;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ShelterApiService {
 
-    private static final String SHELTER_POSH_PATH = "/abandonmentPublic";
+    private static final String SHELTER_POST_PATH = "/abandonmentPublic";
+
+    private static final String ANIMAL_KIND_PATH = "/kind";
+
+    private static final List<String> animalKindCodes = List.of("417000", "422400", "429900");
 
     private final ShelterProperties shelterProperties;
 
     private final WebClient.Builder webClientBuilder;
 
-    public List<ShelterApiPageResult> getShelterApiPageResults(LocalDate candidateForStart) {
+    private final AnimalKindService animalKindService;
+
+
+    private WebClient webClient;
+
+    @PostConstruct
+    public void initWebClient() {
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(getBaseUrl());
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
+        this.webClient = webClientBuilder.uriBuilderFactory(factory).baseUrl(getBaseUrl()).build();
+    }
+
+    public List<ShelterPostCreateParams> getShelterApiPageResultsBySync(LocalDate candidateForStart) {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         LocalDate start = Optional.ofNullable(candidateForStart).orElseGet(() -> yesterday);
         if (start.isAfter(yesterday)) {
@@ -36,25 +61,57 @@ public class ShelterApiService {
         String from = start.format(formatter);
         String to = yesterday.format(formatter);
 
-        List<ShelterApiPageResult> results = new ArrayList<>();
-        Api api = shelterProperties.getApi();
-        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(api.getUrl());
-        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
-
-        WebClient webClient = webClientBuilder.uriBuilderFactory(factory).baseUrl(api.getUrl()).build();
-        webClient.get()
+        List<ShelterPostCreateParams> shelterPostCreateParams = new ArrayList<>();
+        RequestHeadersSpec<?> requestHeadersSpec = webClient.get()
             .uri(uriBuilder -> uriBuilder
-                .path(SHELTER_POSH_PATH)
-                .queryParam("serviceKey", api.getKey())
+                .path(SHELTER_POST_PATH)
+                .queryParam("serviceKey", getApiKey())
                 .queryParam("bgnde", from)
                 .queryParam("endde", to)
                 .build())
-            .accept(MediaType.APPLICATION_XML)
-            .retrieve()
-            .bodyToMono(ShelterApiPageResult.class)
-            .subscribe(results::add);
+            .accept(MediaType.APPLICATION_XML);
 
-        return results;
+        requestHeadersSpec.retrieve()
+            .bodyToMono(ShelterApiPageResult.class)
+            .block();
+
+        // TODO 모든 페이지 call해서 가져오기
+
+        return shelterPostCreateParams;
     }
 
+    public void saveAnimalKinds() {
+        Map<String, AnimalKindCreateParams> createParams = getAnimalKindCreateParams();
+        createParams.forEach(animalKindService::createAnimalKinds);
+    }
+
+    public Map<String, AnimalKindCreateParams> getAnimalKindCreateParams() {
+
+        return animalKindCodes.stream()
+            .collect(Collectors.toMap(
+                kindCode -> kindCode,
+                kindCode -> getAnimalKindApiResults(kindCode).getBodyItems())
+            );
+    }
+
+    public AnimalKindApiPageResults getAnimalKindApiResults(String kind) {
+        return webClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path(ANIMAL_KIND_PATH)
+                .queryParam("serviceKey", getApiKey())
+                .queryParam("up_kind_cd", kind)
+                .build())
+            .accept(MediaType.APPLICATION_XML)
+            .retrieve()
+            .bodyToMono(AnimalKindApiPageResults.class)
+            .block();
+    }
+
+    private String getBaseUrl() {
+        return shelterProperties.getUrl();
+    }
+
+    private String getApiKey() {
+        return shelterProperties.getKey();
+    }
 }

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -40,7 +40,6 @@ public class ShelterApiService {
 
     private final AnimalKindService animalKindService;
 
-
     private WebClient webClient;
 
     @PostConstruct

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,11 @@
 spring:
+  datasource:
+    url: "jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1"
   jpa:
     show-sql: true
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         format_sql: true
     hibernate:
       ddl-auto: create-drop

--- a/src/test/java/com/pet/domains/animal/controller/AnimalKindControllerTest.java
+++ b/src/test/java/com/pet/domains/animal/controller/AnimalKindControllerTest.java
@@ -1,0 +1,61 @@
+package com.pet.domains.animal.controller;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.pet.domains.docs.BaseDocumentationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@DisplayName("동물/품종 컨트롤러 docs 테스트")
+class AnimalKindControllerTest extends BaseDocumentationTest {
+
+    @Test
+    @DisplayName("동물/품종 조회 성공 테스트")
+    void getAnimalsTest() throws Exception {
+        // given
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/animals")
+            .accept(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        resultActions
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(document("get-animals",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName(HttpHeaders.ACCEPT).description(MediaType.APPLICATION_JSON_VALUE)
+                ),
+                responseHeaders(
+                    headerWithName(HttpHeaders.CONTENT_TYPE).description(MediaType.APPLICATION_JSON_VALUE)
+                ),
+                responseFields(
+                    fieldWithPath("data").type(OBJECT).description("응답 데이터"),
+                    fieldWithPath("data.animals").type(ARRAY).description("동물"),
+                    fieldWithPath("data.animals[0].id").type(NUMBER).description("동물 id"),
+                    fieldWithPath("data.animals[0].name").type(STRING).description("동물 이름"),
+                    fieldWithPath("data.animals[0].kinds").type(ARRAY).description("품종 id"),
+                    fieldWithPath("data.animals[0].kinds[0].id").type(NUMBER).description("품종 id"),
+                    fieldWithPath("data.animals[0].kinds[0].name").type(STRING).description("품종 id"),
+                    fieldWithPath("serverDateTime").type(STRING).description("서버 응답 시간")))
+            );
+    }
+}

--- a/src/test/java/com/pet/domains/animal/repository/AnimalKindRepositoryTest.java
+++ b/src/test/java/com/pet/domains/animal/repository/AnimalKindRepositoryTest.java
@@ -14,10 +14,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = @Filter(
-    type = FilterType.ASSIGNABLE_TYPE,
-    classes = JpaAuditingConfig.class
-))
+@DataJpaTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JpaAuditingConfig.class))
 class AnimalKindRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/pet/domains/animal/repository/AnimalKindRepositoryTest.java
+++ b/src/test/java/com/pet/domains/animal/repository/AnimalKindRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.pet.domains.animal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.pet.common.config.JpaAuditingConfig;
+import com.pet.domains.animal.domain.Animal;
+import com.pet.domains.animal.domain.AnimalKind;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest(includeFilters = @Filter(
+    type = FilterType.ASSIGNABLE_TYPE,
+    classes = JpaAuditingConfig.class
+))
+class AnimalKindRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private AnimalKindRepository animalKindRepository;
+
+    @Test
+    @DisplayName("품종명으로 품종 조회 테스트")
+    void findAnimalKindByNameTest() {
+        //Given
+        Animal animal = Animal.builder()
+            .code("1234")
+            .name("testAnimal")
+            .build();
+        entityManager.persist(animal);
+        entityManager.persist(AnimalKind.builder()
+            .name("animalKindName")
+            .animal(animal)
+            .build()
+        );
+        entityManager.flush();
+
+        //When
+        AnimalKind foundAnimalKind = animalKindRepository.findByName("animalKindName").get();
+
+        //Then
+        assertThat(foundAnimalKind.getId()).isNotNull();
+    }
+}

--- a/src/test/java/com/pet/domains/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/pet/domains/animal/repository/AnimalRepositoryTest.java
@@ -13,10 +13,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@DataJpaTest(includeFilters = @Filter(
-    type = FilterType.ASSIGNABLE_TYPE,
-    classes = JpaAuditingConfig.class
-))
+@DataJpaTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JpaAuditingConfig.class))
 class AnimalRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/pet/domains/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/pet/domains/animal/repository/AnimalRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.pet.domains.animal.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.pet.common.config.JpaAuditingConfig;
+import com.pet.domains.animal.domain.Animal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest(includeFilters = @Filter(
+    type = FilterType.ASSIGNABLE_TYPE,
+    classes = JpaAuditingConfig.class
+))
+class AnimalRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private AnimalRepository animalRepository;
+
+    @Test
+    @DisplayName("코드로 동물 조회 테스트")
+    void findAnimalKindByNameTest() {
+        //Given
+        Animal animal = Animal.builder()
+            .code("1234")
+            .name("testAnimal")
+            .build();
+        entityManager.persist(animal);
+        entityManager.flush();
+
+        //When
+        Animal foundAnimal = animalRepository.findByCode("1234").get();
+
+        //Then
+        assertThat(foundAnimal.getId()).isNotNull();
+    }
+
+}


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #122

## 내용
- 설명 : 동물,품종 api 데이터 서비스 추가

## 추가 및 변경 로직
- 동물, 품종, open api 데이터 가져오는 서비스 추가
- h2 mysql 방언 설정
- map struct 의존 추가
- 품종 get or create 서비스 추가
- 품종의 경우 사용자의 입력으로 데이터가 추가될 수 있어 code nullable하게 수정
## 참고 및 기타
- 서비스 단위테스트는 추후 추가하겠습니다.