### PR TITLE
[Cp-142] 데일리 쉘터 게시글 스케줄러 잡 추가

### DIFF
--- a/src/main/java/com/pet/common/config/InitDataConfig.java
+++ b/src/main/java/com/pet/common/config/InitDataConfig.java
@@ -51,7 +51,9 @@ public class InitDataConfig implements ApplicationRunner {
 
         groupPermissionRepository.save(new GroupPermission(group, permission));
         accountRepository.save(tester);
+    }
 
+    public void runShelterPostSchedulerTask() throws InterruptedException {
         String sql = "INSERT INTO animal(created_at, updated_at, code, name)"
             + " VALUES (NOW(), NOW(), '417000','개'),"
             + "       (NOW(), NOW(), '422400','고양이'),"

--- a/src/main/java/com/pet/common/config/InitDataConfig.java
+++ b/src/main/java/com/pet/common/config/InitDataConfig.java
@@ -53,20 +53,16 @@ public class InitDataConfig implements ApplicationRunner {
         accountRepository.save(tester);
     }
 
-    public void runShelterPostSchedulerTask() throws InterruptedException {
+    public void runShelterPostSchedulerTask() {
         String sql = "INSERT INTO animal(created_at, updated_at, code, name)"
             + " VALUES (NOW(), NOW(), '417000','개'),"
             + "       (NOW(), NOW(), '422400','고양이'),"
             + "       (NOW(), NOW(), '429900','기타');";
         jdbcTemplate.execute(sql);
 
-        log.info("sleep start..");
-        Thread.sleep(5000);
-
         log.info("saveAllAnimalKinds start..");
         shelterApiService.saveAllAnimalKinds();
 
-        Thread.sleep(5000);
         log.info("saveAllCities start..");
         shelterApiService.saveAllCities();
 
@@ -74,11 +70,9 @@ public class InitDataConfig implements ApplicationRunner {
             + " SELECT NOW(), NOW(), '0000000', '전체', id FROM city WHERE code = '5690000';";
         jdbcTemplate.execute(sql2);
 
-        Thread.sleep(5000);
         log.info("saveAllTowns start..");
         shelterApiService.saveAllTowns();
 
-        Thread.sleep(5000);
         log.info("shelterPostDailyCronJob start..");
         shelterApiService.shelterPostDailyCronJob();
     }

--- a/src/main/java/com/pet/common/config/InitDataConfig.java
+++ b/src/main/java/com/pet/common/config/InitDataConfig.java
@@ -7,13 +7,14 @@ import com.pet.domains.auth.domain.Group;
 import com.pet.domains.auth.domain.GroupPermission;
 import com.pet.domains.auth.domain.Permission;
 import com.pet.domains.auth.repository.GroupPermissionRepository;
+import com.pet.domains.post.service.ShelterApiService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -23,9 +24,12 @@ public class InitDataConfig implements ApplicationRunner {
 
     private final GroupPermissionRepository groupPermissionRepository;
     private final AccountRepository accountRepository;
+    private final ShelterApiService shelterApiService;
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
+        log.info("runner start");
         String email = "test-user@email.com";
         Group group = new Group("USER_GROUP");
         Permission permission = new Permission("ROLE_USER");
@@ -47,6 +51,34 @@ public class InitDataConfig implements ApplicationRunner {
 
         groupPermissionRepository.save(new GroupPermission(group, permission));
         accountRepository.save(tester);
+
+        String sql = "INSERT INTO animal(created_at, updated_at, code, name)"
+            + " VALUES (NOW(), NOW(), '417000','개'),"
+            + "       (NOW(), NOW(), '422400','고양이'),"
+            + "       (NOW(), NOW(), '429900','기타');";
+        jdbcTemplate.execute(sql);
+
+        log.info("sleep start..");
+        Thread.sleep(5000);
+
+        log.info("saveAllAnimalKinds start..");
+        shelterApiService.saveAllAnimalKinds();
+
+        Thread.sleep(5000);
+        log.info("saveAllCities start..");
+        shelterApiService.saveAllCities();
+
+        String sql2 = "INSERT INTO town (created_at, updated_at, code, name, city_id)"
+            + " SELECT NOW(), NOW(), '0000000', '전체', id FROM city WHERE code = '5690000';";
+        jdbcTemplate.execute(sql2);
+
+        Thread.sleep(5000);
+        log.info("saveAllTowns start..");
+        shelterApiService.saveAllTowns();
+
+        Thread.sleep(5000);
+        log.info("shelterPostDailyCronJob start..");
+        shelterApiService.shelterPostDailyCronJob();
     }
 
 }

--- a/src/main/java/com/pet/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/pet/common/exception/ExceptionMessage.java
@@ -23,9 +23,11 @@ public enum ExceptionMessage {
 
     // 동물
     NOT_FOUND_ANIMAL(new BadRequestException("해당하는 동물 종류를 찾을 수 없습니다.")),
+    NOT_FOUND_ANIMAL_KIND(new BadRequestException("해당하는 품종 종류를 찾을 수 없습니다.")),
 
     // 지역
     NOT_FOUND_CITY(new BadRequestException("해당하는 시도 지역을 찾을 수 없습니다.")),
+    NOT_FOUND_TOWN(new BadRequestException("해당하는 시군구 지역을 찾을 수 없습니다.")),
 
 
     // 인증

--- a/src/main/java/com/pet/domains/animal/dto/response/AnimalKindApiPageResults.java
+++ b/src/main/java/com/pet/domains/animal/dto/response/AnimalKindApiPageResults.java
@@ -1,6 +1,7 @@
 package com.pet.domains.animal.dto.response;
 
 import com.pet.domains.animal.dto.request.AnimalKindCreateParams;
+import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -26,6 +27,7 @@ public class AnimalKindApiPageResults {
     }
 
     public AnimalKindCreateParams getBodyItems() {
+        Objects.requireNonNull(body, "품종 조회 api 응답 바디가 널입니다.");
         return body.getItems();
     }
 }

--- a/src/main/java/com/pet/domains/animal/repository/AnimalRepository.java
+++ b/src/main/java/com/pet/domains/animal/repository/AnimalRepository.java
@@ -8,4 +8,6 @@ public interface AnimalRepository extends JpaRepository<Animal, Long> {
 
     Optional<Animal> findByCode(String code);
 
+    Optional<Animal> findByName(String name);
+
 }

--- a/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
+++ b/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
@@ -7,8 +7,7 @@ import com.pet.domains.animal.domain.AnimalKind;
 import com.pet.domains.animal.dto.request.AnimalKindCreateParams;
 import com.pet.domains.animal.repository.AnimalKindRepository;
 import com.pet.domains.animal.repository.AnimalRepository;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,17 +27,15 @@ public class AnimalKindService {
 
     @Transactional
     public void createAnimalKinds(String animalCode, AnimalKindCreateParams animalKindCreateParams) {
-        List<AnimalKind> animalKinds = new ArrayList<>();
-        Animal animal = getAnimalByCode(animalCode);
-        animalKindCreateParams.getAnimalKinds().forEach(animalKindCreateParam -> animalKinds.add(
-            AnimalKind.builder()
-                .name(animalKindCreateParam.getName())
-                .code(animalKindCreateParam.getCode())
-                .animal(animal)
-                .build()
-            )
+        animalKindRepository.saveAll(
+            animalKindCreateParams.getAnimalKinds().stream()
+                .map(animalKindCreateParam -> AnimalKind.builder()
+                    .name(animalKindCreateParam.getName())
+                    .code(animalKindCreateParam.getCode())
+                    .animal(getAnimalByCode(animalCode))
+                    .build())
+                .collect(Collectors.toList())
         );
-        animalKindRepository.saveAll(animalKinds);
     }
 
     @Transactional
@@ -59,10 +56,9 @@ public class AnimalKindService {
     }
 
     private AnimalKind saveAnimalKindByEtcAnimal(String animalKindName) {
-        Animal etcAnimal = getAnimalByName(ETC_ANIMAL_NAME);
         return animalKindRepository.save(
             AnimalKind.builder()
-                .animal(etcAnimal)
+                .animal(getAnimalByName(ETC_ANIMAL_NAME))
                 .name(animalKindName)
                 .build()
         );

--- a/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
+++ b/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
@@ -7,42 +7,38 @@ import com.pet.domains.animal.domain.AnimalKind;
 import com.pet.domains.animal.dto.request.AnimalKindCreateParams;
 import com.pet.domains.animal.repository.AnimalKindRepository;
 import com.pet.domains.animal.repository.AnimalRepository;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class AnimalKindService {
 
-    private static final int TRANSACTION_CHUNK_LIMIT = 100;
+    private static final String ETC_ANIMAL_NAME = "기타";
 
     private final AnimalKindRepository animalKindRepository;
 
     private final AnimalRepository animalRepository;
 
+    @Transactional
     public void createAnimalKinds(String animalCode, AnimalKindCreateParams animalKindCreateParams) {
-        Set<AnimalKind> transactionChunk = new HashSet<>();
+        List<AnimalKind> animalKinds = new ArrayList<>();
         Animal animal = getAnimalByCode(animalCode);
-        animalKindCreateParams.getAnimalKinds().forEach(animalKindCreateParam -> {
-                transactionChunk.add(AnimalKind.builder()
-                    .name(animalKindCreateParam.getName())
-                    .code(animalKindCreateParam.getCode())
-                    .animal(animal)
-                    .build()
-                );
-                if (transactionChunk.size() == TRANSACTION_CHUNK_LIMIT) {
-                    animalKindRepository.saveAll(transactionChunk);
-                    transactionChunk.clear();
-                    log.info("AnimalKind set has saved with chunk unit");
-                }
-            }
+        animalKindCreateParams.getAnimalKinds().forEach(animalKindCreateParam -> animalKinds.add(
+            AnimalKind.builder()
+                .name(animalKindCreateParam.getName())
+                .code(animalKindCreateParam.getCode())
+                .animal(animal)
+                .build()
+            )
         );
-        animalKindRepository.saveAll(transactionChunk);
+        animalKindRepository.saveAll(animalKinds);
     }
 
     @Transactional
@@ -56,12 +52,36 @@ public class AnimalKindService {
             ));
     }
 
+    @Transactional
+    public AnimalKind getOrCreateByAnimalKindWithEtcAnimal(String animalKindName) {
+        return animalKindRepository.findByName(animalKindName)
+            .orElseGet(() -> saveAnimalKindByEtcAnimal(animalKindName));
+    }
+
+    private AnimalKind saveAnimalKindByEtcAnimal(String animalKindName) {
+        Animal etcAnimal = getAnimalByName(ETC_ANIMAL_NAME);
+        return animalKindRepository.save(
+            AnimalKind.builder()
+                .animal(etcAnimal)
+                .name(animalKindName)
+                .build()
+        );
+    }
+
     private Animal getAnimalByCode(String animalCode) {
+        log.debug("animalCode: {}", animalCode);
         return animalRepository.findByCode(animalCode)
             .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
     }
 
+    private Animal getAnimalByName(String animalName) {
+        log.debug("animalName: {}", animalName);
+        return animalRepository.findByName(animalName)
+            .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
+    }
+
     private Animal getAnimalById(Long animalId) {
+        log.debug("animalId: {}", animalId);
         return animalRepository.findById(animalId)
             .orElseThrow(ExceptionMessage.NOT_FOUND_ANIMAL::getException);
     }

--- a/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
+++ b/src/main/java/com/pet/domains/animal/service/AnimalKindService.java
@@ -42,7 +42,7 @@ public class AnimalKindService {
     }
 
     @Transactional
-    public AnimalKind getOrCreateByAnimalKind(Long animalId, String animalKindName) {
+    public AnimalKind getOrCreateAnimalKind(Long animalId, String animalKindName) {
         return animalKindRepository.findByName(animalKindName)
             .orElseGet(() -> animalKindRepository.save(
                 AnimalKind.builder()
@@ -53,7 +53,7 @@ public class AnimalKindService {
     }
 
     @Transactional
-    public AnimalKind getOrCreateByAnimalKindWithEtcAnimal(String animalKindName) {
+    public AnimalKind getOrCreateAnimalKindByEtcAnimal(String animalKindName) {
         return animalKindRepository.findByName(animalKindName)
             .orElseGet(() -> saveAnimalKindByEtcAnimal(animalKindName));
     }

--- a/src/main/java/com/pet/domains/area/dto/response/CityApiPageResults.java
+++ b/src/main/java/com/pet/domains/area/dto/response/CityApiPageResults.java
@@ -1,6 +1,7 @@
 package com.pet.domains.area.dto.response;
 
 import com.pet.domains.area.dto.request.CityCreateParams;
+import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -11,6 +12,7 @@ import lombok.Getter;
 @XmlRootElement(name = "response")
 @XmlAccessorType(XmlAccessType.NONE)
 public class CityApiPageResults {
+
     @XmlElement(name = "body")
     private CityApiPageResults.Body body;
 
@@ -21,10 +23,10 @@ public class CityApiPageResults {
 
         @XmlElement(name = "items")
         private CityCreateParams items;
-
     }
 
     public CityCreateParams getBodyItems() {
+        Objects.requireNonNull(body, "시도 조회 api 응답 바디가 널입니다.");
         return body.getItems();
     }
 

--- a/src/main/java/com/pet/domains/area/dto/response/TownApiPageResults.java
+++ b/src/main/java/com/pet/domains/area/dto/response/TownApiPageResults.java
@@ -1,6 +1,7 @@
 package com.pet.domains.area.dto.response;
 
 import com.pet.domains.area.dto.request.TownCreateParams;
+import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -11,6 +12,7 @@ import lombok.Getter;
 @XmlRootElement(name = "response")
 @XmlAccessorType(XmlAccessType.NONE)
 public class TownApiPageResults {
+
     @XmlElement(name = "body")
     private TownApiPageResults.Body body;
 
@@ -21,10 +23,10 @@ public class TownApiPageResults {
 
         @XmlElement(name = "items")
         private TownCreateParams items;
-
     }
 
     public TownCreateParams getBodyItems() {
+        Objects.requireNonNull(body, "시군구 조회 api 응답 바디가 널입니다.");
         return body.getItems();
     }
 

--- a/src/main/java/com/pet/domains/post/domain/MissingPost.java
+++ b/src/main/java/com/pet/domains/post/domain/MissingPost.java
@@ -46,8 +46,8 @@ public class MissingPost extends DeletableEntity {
     @Column(name = "date", nullable = false)
     private LocalDate date;
 
-    @Column(name = "age", columnDefinition = "SMALLINT default 0", nullable = false)
-    private int age;
+    @Column(name = "age", columnDefinition = "SMALLINT default 0")
+    private Long age;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 30, nullable = false)
@@ -96,8 +96,7 @@ public class MissingPost extends DeletableEntity {
     @JoinColumn(
         name = "animal_kind_id",
         referencedColumnName = "id",
-        foreignKey = @ForeignKey(name = "fk_animal_kind_to_missing_post"),
-        nullable = false
+        foreignKey = @ForeignKey(name = "fk_animal_kind_to_missing_post")
     )
     private AnimalKind animalKind;
 

--- a/src/main/java/com/pet/domains/post/domain/ShelterPost.java
+++ b/src/main/java/com/pet/domains/post/domain/ShelterPost.java
@@ -2,7 +2,6 @@ package com.pet.domains.post.domain;
 
 import com.pet.domains.BaseEntity;
 import com.pet.domains.animal.domain.AnimalKind;
-import com.pet.domains.area.domain.Town;
 import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,6 +33,9 @@ public class ShelterPost extends BaseEntity {
 
     @Column(name = "age", columnDefinition = "SMALLINT default 0", nullable = false)
     private int age;
+
+    @Column(name = "address", length = 50, nullable = false)
+    private String address;
 
     @Column(name = "shelter_place", length = 200, nullable = false)
     private String shelterPlace;
@@ -92,12 +95,8 @@ public class ShelterPost extends BaseEntity {
     @Column(name = "notice_number", length = 30, nullable = false)
     private String noticeNumber;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "town_id",
-        referencedColumnName = "id",
-        nullable = false,
-        foreignKey = @ForeignKey(name = "fk_town_to_shelter_post"))
-    private Town town;
+    @Column(name = "bookmark_count", columnDefinition = "BIGINT default 0", nullable = false)
+    private long bookmarkCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "animal_kind_id",
@@ -106,12 +105,14 @@ public class ShelterPost extends BaseEntity {
         foreignKey = @ForeignKey(name = "fk_animal_kind_to_shelter_post"))
     private AnimalKind animalKind;
 
-    public ShelterPost(int age, String shelterPlace, String shelterName, String shelterTelNumber, String manager,
-        String color, String desertionNumber, String image, String thumbnail, LocalDate foundDate,
+    @Builder
+    public ShelterPost(int age, String address, String shelterPlace, String shelterName, String shelterTelNumber,
+        String manager, String color, String desertionNumber, String image, String thumbnail, LocalDate foundDate,
         String foundPlace, NeuteredType neutered, LocalDate startDate, LocalDate endDate, String managerTelNumber,
-        String postStatus, SexType sex, String feature, Double weight, String noticeNumber,
-        Town town, AnimalKind animalKind) {
+        String postStatus, SexType sex, String feature, Double weight, String noticeNumber, long bookmarkCount,
+        AnimalKind animalKind) {
         this.age = age;
+        this.address = address;
         this.shelterPlace = shelterPlace;
         this.shelterName = shelterName;
         this.shelterTelNumber = shelterTelNumber;
@@ -131,7 +132,7 @@ public class ShelterPost extends BaseEntity {
         this.feature = feature;
         this.weight = weight;
         this.noticeNumber = noticeNumber;
-        this.town = town;
+        this.bookmarkCount = bookmarkCount;
         this.animalKind = animalKind;
     }
 }

--- a/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
+++ b/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
@@ -82,7 +82,7 @@ public class ShelterPostCreateParams {
         private String managerTelNumber;
 
         @XmlElement(name = "orgNm")
-        private String orgNm;
+        private String address;
 
         @XmlElement(name = "popfile")
         private String image;
@@ -101,11 +101,18 @@ public class ShelterPostCreateParams {
         @XmlElement(name = "weight")
         private Double weight;
 
+        public String getAnimalKindNameFromKindCd() {
+            // format: [{동물}] {품종}, ex) [고양이] 한국 고양이
+            System.out.println(kindCd);
+            int whileSpaceIdx = StringUtils.indexOf(kindCd, " ");
+            return StringUtils.substring(kindCd, whileSpaceIdx + 1).strip();
+        }
 
         public static class AgeAdapter extends XmlAdapter<String, Long> {
 
             @Override
             public Long unmarshal(String value) {
+                // format: {년도}(년생), ex) 2021(년생)
                 String extractedAge = StringUtils.substringBefore(value, "(");
                 return Long.valueOf(extractedAge);
             }
@@ -160,6 +167,7 @@ public class ShelterPostCreateParams {
 
             @Override
             public Double unmarshal(String value) {
+                // format: {몸무게}(kg), ex) 20.00(kg)
                 String extractedWeight = StringUtils.substringBefore(value, "(");
                 return Double.valueOf(extractedWeight);
             }

--- a/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
+++ b/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
@@ -103,7 +103,6 @@ public class ShelterPostCreateParams {
 
         public String getAnimalKindNameFromKindCd() {
             // format: [{동물}] {품종}, ex) [고양이] 한국 고양이
-            System.out.println(kindCd);
             int whileSpaceIdx = StringUtils.indexOf(kindCd, " ");
             return StringUtils.substring(kindCd, whileSpaceIdx + 1).strip();
         }

--- a/src/main/java/com/pet/domains/post/dto/response/ShelterApiPageResult.java
+++ b/src/main/java/com/pet/domains/post/dto/response/ShelterApiPageResult.java
@@ -1,6 +1,7 @@
 package com.pet.domains.post.dto.response;
 
 import com.pet.domains.post.dto.request.ShelterPostCreateParams;
+import java.util.Objects;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -32,5 +33,10 @@ public class ShelterApiPageResult {
 
         @XmlElement(name = "items")
         private ShelterPostCreateParams items;
+    }
+
+    public ShelterPostCreateParams getBodyItems() {
+        Objects.requireNonNull(body, "보호소 동물 조회 api 응답 바디가 널입니다.");
+        return body.getItems();
     }
 }

--- a/src/main/java/com/pet/domains/post/mapper/ShelterPostMapper.java
+++ b/src/main/java/com/pet/domains/post/mapper/ShelterPostMapper.java
@@ -1,0 +1,19 @@
+package com.pet.domains.post.mapper;
+
+import com.pet.domains.animal.domain.AnimalKind;
+import com.pet.domains.post.domain.ShelterPost;
+import com.pet.domains.post.dto.request.ShelterPostCreateParams;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface ShelterPostMapper {
+
+    @Mapping(target = "bookmarkCount", expression = "java(0)")
+    @Mapping(target = "animalKind", source = "animalKindEntity")
+    ShelterPost toEntity(
+        ShelterPostCreateParams.ShelterPost param,
+        AnimalKind animalKindEntity
+    );
+
+}

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -99,7 +99,7 @@ public class ShelterApiService {
 
     public void saveAllShelterApiRemainingPageResults(String date, List<Long> pageNumbersForRequest) {
         log.info("saveAllShelterApiRemainingPageResults() start");
-        getShelterApiRemainingPageResults("20211210", "20211211", pageNumbersForRequest)
+        getShelterApiRemainingPageResults(date, date, pageNumbersForRequest)
             .subscribe(response -> {
                 shelterService.bulkCreateShelterPosts(response.getBodyItems());
                 log.info("Get shelter post api async");

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -93,17 +93,17 @@ public class ShelterApiService {
     }
 
     public long insertShelterPostFromFirstPageResults(ShelterApiPageResult result) {
-        log.info("insert ShelterApi FirstPage Results");
+        log.info("보호소 동물 게시글 api 첫번째 페이지 응답 데이터 테이블에 삽입 시작");
         shelterService.bulkCreateShelterPosts(Objects.requireNonNull(result, "보호소 게시글 api 응답이 널입니다.").getBodyItems());
         return result.getBody().getTotalCount();
     }
 
     public void insertShelterPostFromRemainingPageResults(String start, String end, List<Long> pageNumbersForRequest) {
-        log.info("saveAllShelterApiRemainingPageResults() start");
+        log.info("보호소 동물 게시글 api 나머지 페이지들의 응답 데이터 테이블에 삽입 시작");
         getShelterApiRemainingPageResults(start, end, pageNumbersForRequest)
             .subscribe(response -> {
                 shelterService.bulkCreateShelterPosts(response.getBodyItems());
-                log.info("Get shelter post api async");
+                log.info("Get shelter post api response async");
             });
     }
 

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -87,8 +87,6 @@ public class ShelterApiService {
 
     public void saveShelterApiFirstPageResults(String start, String end) {
         log.info("saveShelterApiFirstPageResults() start");
-
-
         ShelterApiPageResult result = getShelterApiPageResults(start, end, 1)
             .block();
         shelterService.bulkCreateShelterPosts(Objects.requireNonNull(result, "보호소 게시글 api 응답이 널입니다.").getBodyItems());

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -75,7 +75,7 @@ public class ShelterApiService {
             .build();
     }
 
-    @Scheduled(cron = "0 0 4 * * *")
+    @Scheduled(cron = "0 0 5 * * *")
     public void shelterPostDailyCronJob() {
         LocalDateTime now = LocalDateTime.now();
         log.info("shelterPostDailyCronJob() start at {}, ", now);

--- a/src/main/java/com/pet/domains/post/service/ShelterApiService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterApiService.java
@@ -11,18 +11,17 @@ import com.pet.domains.area.dto.response.CityApiPageResults;
 import com.pet.domains.area.dto.response.TownApiPageResults;
 import com.pet.domains.area.service.CityService;
 import com.pet.domains.area.service.TownService;
-import com.pet.domains.post.dto.request.ShelterPostCreateParams;
 import com.pet.domains.post.dto.response.ShelterApiPageResult;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,8 +29,9 @@ import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClient.RequestHeadersSpec;
 import org.springframework.web.util.DefaultUriBuilderFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -48,11 +48,13 @@ public class ShelterApiService {
 
     private static final List<String> animalKindCodes = List.of("417000", "422400", "429900");
 
-    private static final int NUM_OF_ROWS = 100;
+    private static final long NUM_OF_ROWS = 100;
 
     private final ShelterProperties shelterProperties;
 
     private final WebClient.Builder webClientBuilder;
+
+    private final ShelterService shelterService;
 
     private final AnimalKindService animalKindService;
 
@@ -62,41 +64,72 @@ public class ShelterApiService {
 
     private WebClient webClient;
 
+
     @PostConstruct
     public void initWebClient() {
-        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(getBaseUrl());
+        String baseUrl = shelterProperties.getUrl();
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(baseUrl);
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
-        this.webClient = webClientBuilder.uriBuilderFactory(factory).baseUrl(getBaseUrl()).build();
+        webClient = webClientBuilder
+            .uriBuilderFactory(factory)
+            .baseUrl(baseUrl)
+            .build();
     }
 
-    public List<ShelterPostCreateParams> getShelterApiPageResultsBySync(LocalDate candidateForStart) {
-        LocalDate yesterday = LocalDate.now().minusDays(1);
-        LocalDate start = Optional.ofNullable(candidateForStart).orElseGet(() -> yesterday);
-        if (start.isAfter(yesterday)) {
-            return Collections.emptyList();
-        }
+    @Scheduled(cron = "0 0 4 * * *")
+    public void shelterPostDailyCronJob() {
+        log.info("shelterPostDailyCronJob() start at {}, ", LocalDateTime.now());
+        saveShelterApiFirstPageResults();
+    }
 
+    public void saveShelterApiFirstPageResults() {
+        log.info("saveShelterApiFirstPageResults() start");
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
-        String from = start.format(formatter);
-        String to = yesterday.format(formatter);
+        String yesterday = LocalDate.now().minusDays(1).format(formatter);
 
-        List<ShelterPostCreateParams> shelterPostCreateParams = new ArrayList<>();
-        RequestHeadersSpec<?> requestHeadersSpec = webClient.get()
+        ShelterApiPageResult result = getShelterApiPageResults(yesterday, yesterday, 1)
+            .block();
+        shelterService.bulkCreateShelterPosts(Objects.requireNonNull(result, "보호소 게시글 api 응답이 널입니다.").getBodyItems());
+        long lastPageNumber = getLastPageNumber(result.getBody().getTotalCount());
+        List<Long> pageNumbersForRequest = LongStream.rangeClosed(2, lastPageNumber)
+            .boxed()
+            .collect(Collectors.toList());
+        saveAllShelterApiRemainingPageResults(yesterday, pageNumbersForRequest);
+    }
+
+    public void saveAllShelterApiRemainingPageResults(String date, List<Long> pageNumbersForRequest) {
+        log.info("saveAllShelterApiRemainingPageResults() start");
+        getShelterApiRemainingPageResults("20211210", "20211211", pageNumbersForRequest)
+            .subscribe(response -> {
+                shelterService.bulkCreateShelterPosts(response.getBodyItems());
+                log.info("Get shelter post api async");
+            });
+    }
+
+    public Flux<ShelterApiPageResult> getShelterApiRemainingPageResults(String start, String end,
+        List<Long> pageNumbers) {
+        return Flux.fromIterable(pageNumbers)
+            .flatMap(pageNumber -> getShelterApiPageResults(start, end, pageNumber))
+            .doOnComplete(() -> log.info("created ShelterApiPageResult flux "));
+    }
+
+    public Mono<ShelterApiPageResult> getShelterApiPageResults(
+        String start,
+        String end,
+        long pageNumber
+    ) {
+        return webClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path(SHELTER_POST_PATH)
-                .queryParam("serviceKey", getApiKey())
-                .queryParam("bgnde", from)
-                .queryParam("endde", to)
+                .queryParam("serviceKey", shelterProperties.getKey())
+                .queryParam("bgnde", start)
+                .queryParam("endde", end)
+                .queryParam("numOfRows", NUM_OF_ROWS)
+                .queryParam("pageNo", pageNumber)
                 .build())
-            .accept(MediaType.APPLICATION_XML);
-
-        requestHeadersSpec.retrieve()
-            .bodyToMono(ShelterApiPageResult.class)
-            .block();
-
-        // TODO 모든 페이지 call해서 가져오기
-
-        return shelterPostCreateParams;
+            .accept(MediaType.APPLICATION_XML)
+            .retrieve()
+            .bodyToMono(ShelterApiPageResult.class);
     }
 
     public void saveAllAnimalKinds() {
@@ -116,7 +149,7 @@ public class ShelterApiService {
         return webClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path(ANIMAL_KIND_PATH)
-                .queryParam("serviceKey", getApiKey())
+                .queryParam("serviceKey", shelterProperties.getKey())
                 .queryParam("up_kind_cd", kind)
                 .build())
             .accept(MediaType.APPLICATION_XML)
@@ -125,8 +158,6 @@ public class ShelterApiService {
             .block();
     }
 
-    // 매년, 12/11 13시, dev rds에 migrate 후 삭제
-    @Scheduled(cron = "0 40 13 11 12 ?")
     public void saveAllCities() {
         log.info("saveAllCities() cron task start");
         CityCreateParams createParams = getCityCreateParams();
@@ -137,12 +168,11 @@ public class ShelterApiService {
         return getCityApiPageResults().getBodyItems();
     }
 
-
     public CityApiPageResults getCityApiPageResults() {
         return webClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path(CITY_PATH)
-                .queryParam("serviceKey", getApiKey())
+                .queryParam("serviceKey", shelterProperties.getKey())
                 .queryParam("numOfRows", NUM_OF_ROWS)
                 .build())
             .accept(MediaType.APPLICATION_XML)
@@ -151,8 +181,6 @@ public class ShelterApiService {
             .block();
     }
 
-    // 매년, 12/11 13시 10, dev rds에 migrate 후 삭제
-    @Scheduled(cron = "0 50 13 11 12 ?")
     public void saveAllTowns() {
         log.info("saveAllTowns() cron task start");
         Map<String, TownCreateParams> createParams = getAllTownCreateParams();
@@ -181,7 +209,7 @@ public class ShelterApiService {
         return webClient.get()
             .uri(uriBuilder -> uriBuilder
                 .path(TOWN_PATH)
-                .queryParam("serviceKey", getApiKey())
+                .queryParam("serviceKey", shelterProperties.getKey())
                 .queryParam("upr_cd", cityCode)
                 .build())
             .accept(MediaType.APPLICATION_XML)
@@ -190,11 +218,15 @@ public class ShelterApiService {
             .block();
     }
 
-    private String getBaseUrl() {
-        return shelterProperties.getUrl();
+    private long getLastPageNumber(long totalCount) {
+        long lastPageNumber = (totalCount / NUM_OF_ROWS);
+        if (hasRemainder(totalCount)) {
+            lastPageNumber++;
+        }
+        return lastPageNumber;
     }
 
-    private String getApiKey() {
-        return shelterProperties.getKey();
+    private boolean hasRemainder(long divided) {
+        return (divided % NUM_OF_ROWS) != 0;
     }
 }

--- a/src/main/java/com/pet/domains/post/service/ShelterService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterService.java
@@ -2,12 +2,10 @@ package com.pet.domains.post.service;
 
 import com.pet.domains.animal.domain.AnimalKind;
 import com.pet.domains.animal.service.AnimalKindService;
-import com.pet.domains.post.domain.ShelterPost;
 import com.pet.domains.post.dto.request.ShelterPostCreateParams;
 import com.pet.domains.post.mapper.ShelterPostMapper;
 import com.pet.domains.post.repository.ShelterPostRepository;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,14 +25,11 @@ public class ShelterService {
 
     @Transactional
     public void bulkCreateShelterPosts(ShelterPostCreateParams shelterPostCreateParams) {
-        List<ShelterPost> shelterPosts = new ArrayList<>();
-        shelterPostCreateParams.getShelterPosts().forEach(createParam -> shelterPosts.add(
-            shelterPostMapper.toEntity(
-                createParam,
-                getAnimalKind(createParam.getAnimalKindNameFromKindCd())
-            )
-        ));
-        shelterPostRepository.saveAll(shelterPosts);
+        shelterPostRepository.saveAll(shelterPostCreateParams.getShelterPosts().stream()
+            .map(shelterPostCreateParam -> shelterPostMapper.toEntity(
+                shelterPostCreateParam,
+                getAnimalKind(shelterPostCreateParam.getAnimalKindNameFromKindCd())
+            )).collect(Collectors.toList()));
     }
 
     private AnimalKind getAnimalKind(String animalKindName) {

--- a/src/main/java/com/pet/domains/post/service/ShelterService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterService.java
@@ -1,10 +1,19 @@
 package com.pet.domains.post.service;
 
+import com.pet.domains.animal.domain.AnimalKind;
+import com.pet.domains.animal.service.AnimalKindService;
+import com.pet.domains.post.domain.ShelterPost;
+import com.pet.domains.post.dto.request.ShelterPostCreateParams;
+import com.pet.domains.post.mapper.ShelterPostMapper;
 import com.pet.domains.post.repository.ShelterPostRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -12,5 +21,24 @@ public class ShelterService {
 
     private final ShelterPostRepository shelterPostRepository;
 
+    private final AnimalKindService animalKindService;
 
+    private final ShelterPostMapper shelterPostMapper;
+
+    @Transactional
+    public void bulkCreateShelterPosts(ShelterPostCreateParams shelterPostCreateParams) {
+        List<ShelterPost> shelterPosts = new ArrayList<>();
+        shelterPostCreateParams.getShelterPosts().forEach(createParam -> shelterPosts.add(
+            shelterPostMapper.toEntity(
+                createParam,
+                getAnimalKind(createParam.getAnimalKindNameFromKindCd())
+            )
+        ));
+        shelterPostRepository.saveAll(shelterPosts);
+    }
+
+    private AnimalKind getAnimalKind(String animalKindName) {
+        log.info("animalKindName: {}", animalKindName);
+        return animalKindService.getOrCreateByAnimalKindWithEtcAnimal(animalKindName);
+    }
 }

--- a/src/main/java/com/pet/domains/post/service/ShelterService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterService.java
@@ -39,6 +39,6 @@ public class ShelterService {
 
     private AnimalKind getAnimalKind(String animalKindName) {
         log.info("animalKindName: {}", animalKindName);
-        return animalKindService.getOrCreateByAnimalKindWithEtcAnimal(animalKindName);
+        return animalKindService.getOrCreateAnimalKindByEtcAnimal(animalKindName);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         format_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
   servlet:
     multipart:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         format_sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     open-in-view: false
   servlet:
     multipart:

--- a/src/main/resources/data-h2.sql
+++ b/src/main/resources/data-h2.sql
@@ -1,0 +1,8 @@
+INSERT INTO animal(created_at, updated_at, code, name)
+VALUES (NOW(), NOW(), '417000','개'),
+       (NOW(), NOW(), '422400','고양이'),
+       (NOW(), NOW(), '429900','기타')
+;
+
+INSERT INTO town (created_at, updated_at, code, name, city_id)
+SELECT NOW(), NOW(), '0000000', '전체', id FROM city WHERE code = '5690000';

--- a/src/test/java/com/pet/domains/animal/repository/AnimalRepositoryTest.java
+++ b/src/test/java/com/pet/domains/animal/repository/AnimalRepositoryTest.java
@@ -25,7 +25,7 @@ class AnimalRepositoryTest {
 
     @Test
     @DisplayName("코드로 Animal 조회 테스트")
-    void findAnimalByNameTest() {
+    void findAnimalByCodeTest() {
         // given
         Animal animal = Animal.builder()
             .code("1234")
@@ -35,6 +35,23 @@ class AnimalRepositoryTest {
 
         // when
         Animal foundAnimal = animalRepository.findByCode("1234").get();
+
+        // then
+        assertThat(foundAnimal.getId()).isEqualTo(animal.getId());
+    }
+
+    @Test
+    @DisplayName("이름로 Animal 조회 테스트")
+    void findAnimalByNameTest() {
+        // given
+        Animal animal = Animal.builder()
+            .code("1234")
+            .name("testAnimal")
+            .build();
+        entityManager.persist(animal);
+
+        // when
+        Animal foundAnimal = animalRepository.findByName("testAnimal").get();
 
         // then
         assertThat(foundAnimal.getId()).isEqualTo(animal.getId());


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #142 

## 내용
- 설명 : 매일 4시 어제날짜의 보호소 게시글 데이터를 테이블에 넣는 스케줄러 잡 추가

## 추가 및 변경 로직
- 매일 새벽 5시에 게시글 api 동기 호출 
   -> 요청해야하는 페이지 수 계산 -> 비동기 호출 -> bulk create
- 실종 게시글의 나이, 품종 nullable 하게 수정(모름 옵션)
- 보호소 게시글의 지역이 너무나 불규칙하여 모든 경우로 파싱하여 연관관계로 잡기 어려운 상황이라 raw하게 수정
  - ex) 시군구가 없는경우, 시군구가 우리 데이터랑 다르게 들어오는 경우, 시군구 데이터가 oo시 oo구인 경우 등등
  - 품종의 경우도 정말 다양하고 불규칙하게 들어오는데 이경우는 animalkind를 get or create 하는 방식으로 진행했씁니다. (기타 animal 외래키 )
- 세종특별자치시는 시군구가 없어 "전체"라는 이름과 "000000"코드를 가지는 데이터 추가했습니다.
  - 품종과 달리, 시군구는 애플리케이션단으로 가지고 있기에는 별로라고 판단 


## 참고 및 기타
