### PR TITLE
[CP-186] account sign status 안쓰는 필드삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,11 @@ jacocoTestReport {
 }
 
 jacocoTestCoverageVerification {
+    def Qdomains = []
+
+    for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+        Qdomains.add(qPattern + '*')
+    }
     violationRules {
         rule {
             enabled = true
@@ -140,7 +145,7 @@ jacocoTestCoverageVerification {
                 value = 'COVEREDRATIO'
                 minimum = 0.00
             }
-            excludes = []
+            excludes = [] + Qdomains
         }
     }
 }

--- a/src/main/java/com/pet/common/config/InitDataConfig.java
+++ b/src/main/java/com/pet/common/config/InitDataConfig.java
@@ -1,7 +1,6 @@
 package com.pet.common.config;
 
 import com.pet.domains.account.domain.Account;
-import com.pet.domains.account.domain.SignStatus;
 import com.pet.domains.account.repository.AccountRepository;
 import com.pet.domains.auth.domain.Group;
 import com.pet.domains.auth.domain.GroupPermission;
@@ -39,7 +38,6 @@ public class InitDataConfig implements ApplicationRunner {
             "tester",
             true,
             true,
-            SignStatus.SUCCESS,
             null,
             group);
 

--- a/src/main/java/com/pet/domains/account/domain/Account.java
+++ b/src/main/java/com/pet/domains/account/domain/Account.java
@@ -5,11 +5,9 @@ import com.pet.domains.DeletableEntity;
 import com.pet.domains.auth.domain.Group;
 import com.pet.domains.image.domain.Image;
 import java.util.Objects;
-import java.util.StringJoiner;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
@@ -58,8 +56,6 @@ public class Account extends DeletableEntity {
     @Column(name = "checked_area", columnDefinition = "boolean default false")
     private boolean checkedArea;
 
-    private SignStatus signStatus;
-
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id",
         referencedColumnName = "id",
@@ -79,13 +75,12 @@ public class Account extends DeletableEntity {
 
     @Builder
     public Account(String email, String password, String nickname, boolean notification, boolean checkedArea,
-        SignStatus signStatus, Image image, Group group) {
+        Image image, Group group) {
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.notification = notification;
         this.checkedArea = checkedArea;
-        this.signStatus = signStatus;
         this.image = image;
         this.group = group;
     }

--- a/src/main/java/com/pet/domains/account/domain/SignStatus.java
+++ b/src/main/java/com/pet/domains/account/domain/SignStatus.java
@@ -1,6 +1,0 @@
-package com.pet.domains.account.domain;
-
-public enum SignStatus {
-    VERIFICATION,
-    SUCCESS;
-}

--- a/src/test/java/com/pet/domains/account/WithAccountSecurityContextFactory.java
+++ b/src/test/java/com/pet/domains/account/WithAccountSecurityContextFactory.java
@@ -1,10 +1,11 @@
 package com.pet.domains.account;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
 import com.pet.common.jwt.JwtAuthenticationProvider;
 import com.pet.common.jwt.JwtAuthenticationToken;
 import com.pet.domains.account.domain.Account;
-import com.pet.domains.account.domain.SignStatus;
 import com.pet.domains.account.service.AccountService;
 import com.pet.domains.auth.domain.Group;
 import java.util.List;
@@ -47,7 +48,6 @@ public class WithAccountSecurityContextFactory implements WithSecurityContextFac
             nickname,
             true,
             true,
-            SignStatus.SUCCESS,
             null,
             group,
             "local");

--- a/src/test/java/com/pet/domains/post/service/MissingPostServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/MissingPostServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import com.pet.domains.account.domain.Account;
-import com.pet.domains.account.domain.SignStatus;
 import com.pet.domains.animal.domain.Animal;
 import com.pet.domains.animal.domain.AnimalKind;
 import com.pet.domains.animal.service.AnimalKindService;
@@ -100,7 +99,7 @@ class MissingPostServiceTest {
         group = new Group("1그룹");
 
         account =
-            new Account("aaa@naver.com", "user123", "nickName", false, false, SignStatus.VERIFICATION, image,
+            new Account("aaa@naver.com", "user123", "nickName", false, false, image,
                 group);
 
         city = City.builder()


### PR DESCRIPTION
## PR 종류

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [x] Chore
- [ ] Init 

close #186 

## 내용 
- 설명 : account sign status 안쓰는 필드삭제

## 추가 및 변경 로직
- 추가로 q 객체들 자코코 제외했습니다.

## 참고 및 기타
