### PR TITLE
[CP-171] 실종/보호 게시물 북마크 등록 API

### DIFF
--- a/src/main/java/com/pet/domains/post/controller/MissingPostController.java
+++ b/src/main/java/com/pet/domains/post/controller/MissingPostController.java
@@ -10,6 +10,7 @@ import com.pet.domains.post.dto.request.MissingPostUpdateParam;
 import com.pet.domains.post.dto.response.MissingPostCommentPageResults;
 import com.pet.domains.post.dto.response.MissingPostReadResult;
 import com.pet.domains.post.dto.response.MissingPostReadResults;
+import com.pet.domains.post.service.MissingPostBookmarkService;
 import com.pet.domains.post.service.MissingPostService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,6 +45,8 @@ public class MissingPostController {
     private static final String RETURN_KEY = "id";
 
     private final MissingPostService missingPostService;
+
+    private final MissingPostBookmarkService missingPostBookmarkService;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
@@ -204,8 +207,9 @@ public class MissingPostController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(path = "/{postId}/bookmark")
-    public void createMissingPostBookmark(@PathVariable Long postId) {
+    public void createMissingPostBookmark(@PathVariable Long postId, @LoginAccount Account account) {
         log.info("실종/보호 북마크 생성 call for {}", postId);
+        missingPostBookmarkService.createMissingPostBookmark(postId, account);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/pet/domains/post/domain/MissingPostBookmark.java
+++ b/src/main/java/com/pet/domains/post/domain/MissingPostBookmark.java
@@ -13,8 +13,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,5 +42,14 @@ public class MissingPostBookmark extends BaseEntity {
         nullable = false,
         foreignKey = @ForeignKey(name = "fk_missing_post_to_missing_book_mark"))
     private MissingPost missingPost;
+
+    @Builder
+    public MissingPostBookmark(Account account, MissingPost missingPost) {
+        ObjectUtils.requireNonEmpty(account, "account must not be null");
+        ObjectUtils.requireNonEmpty(missingPost, "missingPost must not be null");
+
+        this.account = account;
+        this.missingPost = missingPost;
+    }
 
 }

--- a/src/main/java/com/pet/domains/post/repository/MissingPostBookmarkRepository.java
+++ b/src/main/java/com/pet/domains/post/repository/MissingPostBookmarkRepository.java
@@ -1,0 +1,8 @@
+package com.pet.domains.post.repository;
+
+import com.pet.domains.post.domain.MissingPostBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissingPostBookmarkRepository extends JpaRepository<MissingPostBookmark, Long> {
+
+}

--- a/src/main/java/com/pet/domains/post/service/MissingPostBookmarkService.java
+++ b/src/main/java/com/pet/domains/post/service/MissingPostBookmarkService.java
@@ -1,0 +1,35 @@
+package com.pet.domains.post.service;
+
+import com.pet.common.exception.ExceptionMessage;
+import com.pet.domains.account.domain.Account;
+import com.pet.domains.post.domain.MissingPost;
+import com.pet.domains.post.domain.MissingPostBookmark;
+import com.pet.domains.post.repository.MissingPostBookmarkRepository;
+import com.pet.domains.post.repository.MissingPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MissingPostBookmarkService {
+
+    private final MissingPostRepository missingPostRepository;
+
+    private final MissingPostBookmarkRepository missingPostBookmarkRepository;
+
+    @Transactional
+    public void createMissingPostBookmark(Long postId, Account account) {
+        MissingPost getMissingPost = missingPostRepository.findById(postId)
+            .orElseThrow(ExceptionMessage.NOT_FOUND_MISSING_POST::getException);
+
+        missingPostBookmarkRepository.save(
+            MissingPostBookmark.builder()
+                .account(account)
+                .missingPost(getMissingPost)
+                .build()
+        );
+    }
+
+}

--- a/src/test/java/com/pet/domains/docs/BaseDocumentationTest.java
+++ b/src/test/java/com/pet/domains/docs/BaseDocumentationTest.java
@@ -18,6 +18,7 @@ import com.pet.domains.docs.controller.CommonDocumentationController;
 import com.pet.domains.image.service.ImageService;
 import com.pet.domains.post.controller.MissingPostController;
 import com.pet.domains.post.controller.ShelterPostController;
+import com.pet.domains.post.service.MissingPostBookmarkService;
 import com.pet.domains.post.service.MissingPostService;
 import com.pet.domains.post.service.ShelterPostBookmarkService;
 import com.pet.domains.post.service.ShelterPostService;
@@ -79,6 +80,9 @@ public abstract class BaseDocumentationTest {
 
     @MockBean
     protected ShelterPostService shelterPostService;
+
+    @MockBean
+    protected MissingPostBookmarkService missingPostBookmarkService;
 
     protected JwtAuthentication getAuthenticationToken() {
         return (JwtAuthentication) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/src/test/java/com/pet/domains/post/service/MissingPostBookmarkServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/MissingPostBookmarkServiceTest.java
@@ -1,0 +1,51 @@
+package com.pet.domains.post.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import com.pet.domains.post.domain.MissingPost;
+import com.pet.domains.post.domain.MissingPostBookmark;
+import com.pet.domains.post.repository.MissingPostBookmarkRepository;
+import com.pet.domains.post.repository.MissingPostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("실종/보호 게시물 북마크 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class MissingPostBookmarkServiceTest {
+
+    @InjectMocks
+    private MissingPostBookmarkService missingPostBookmarkService;
+
+    @Mock
+    private MissingPostBookmarkRepository missingPostBookmarkRepository;
+
+    @Mock
+    private MissingPostRepository missingPostRepository;
+
+    @Test
+    @DisplayName("실종/보호 게시물 북마크 생성 테스트")
+    void createMissingPostBookmarkTest() {
+        //given
+        given(missingPostRepository.findById(anyLong())).willReturn(
+            java.util.Optional.ofNullable(mock(MissingPost.class)));
+        given(missingPostBookmarkRepository.save(any())).willReturn(
+            mock(MissingPostBookmark.class));
+
+        //when
+        missingPostRepository.findById(1L);
+        missingPostBookmarkRepository.save(mock(MissingPostBookmark.class));
+
+        //then
+        verify(missingPostRepository, times(1)).findById(anyLong());
+        verify(missingPostBookmarkRepository, times(1)).save(any());
+    }
+
+}


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #171

## 내용
- 설명 : 실종/보호 게시물 북마크를 등록하는 API입니다.

## 추가 및 변경 로직
- change

## 참고 및 기타
