### PR TITLE
[CP-190] 실종/보호 게시물 북마크 삭제 API

### DIFF
--- a/src/main/java/com/pet/domains/post/controller/MissingPostController.java
+++ b/src/main/java/com/pet/domains/post/controller/MissingPostController.java
@@ -214,8 +214,9 @@ public class MissingPostController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping(path = "/{postId}/bookmark")
-    public void deleteMissingPostBookmark(@PathVariable Long postId) {
+    public void deleteMissingPostBookmark(@PathVariable Long postId, @LoginAccount Account account) {
         log.info("실종/보호 북마크 삭제 call for {}", postId);
+        missingPostBookmarkService.deleteMissingPostBookmark(postId, account);
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/pet/domains/post/domain/MissingPostBookmark.java
+++ b/src/main/java/com/pet/domains/post/domain/MissingPostBookmark.java
@@ -16,7 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.Validate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -45,8 +45,8 @@ public class MissingPostBookmark extends BaseEntity {
 
     @Builder
     public MissingPostBookmark(Account account, MissingPost missingPost) {
-        ObjectUtils.requireNonEmpty(account, "account must not be null");
-        ObjectUtils.requireNonEmpty(missingPost, "missingPost must not be null");
+        Validate.notNull(account, "account must not be null");
+        Validate.notNull(missingPost, "missingPost must not be null");
 
         this.account = account;
         this.missingPost = missingPost;

--- a/src/main/java/com/pet/domains/post/repository/MissingPostBookmarkRepository.java
+++ b/src/main/java/com/pet/domains/post/repository/MissingPostBookmarkRepository.java
@@ -1,8 +1,11 @@
 package com.pet.domains.post.repository;
 
+import com.pet.domains.account.domain.Account;
 import com.pet.domains.post.domain.MissingPostBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissingPostBookmarkRepository extends JpaRepository<MissingPostBookmark, Long> {
+
+    void deleteByMissingPostIdAndAccount(Long postId, Account account);
 
 }

--- a/src/main/java/com/pet/domains/post/service/MissingPostBookmarkService.java
+++ b/src/main/java/com/pet/domains/post/service/MissingPostBookmarkService.java
@@ -32,4 +32,9 @@ public class MissingPostBookmarkService {
         );
     }
 
+    @Transactional
+    public void deleteMissingPostBookmark(Long postId, Account account) {
+        missingPostBookmarkRepository.deleteByMissingPostIdAndAccount(postId, account);
+    }
+
 }

--- a/src/test/java/com/pet/domains/post/controller/MissingPostControllerTest.java
+++ b/src/test/java/com/pet/domains/post/controller/MissingPostControllerTest.java
@@ -323,12 +323,13 @@ class MissingPostControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("실종/보호 게시글 북마크 생성 테스트")
     void createMissingPostBookmarkTest() throws Exception {
         // given
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/v1/missing-posts/{postId}/bookmark", 1L)
-            .header(HttpHeaders.AUTHORIZATION, JwtMockToken.MOCK_TOKEN));
+            .header(HttpHeaders.AUTHORIZATION, getAuthenticationToken()));
 
         // then
         resultActions
@@ -346,12 +347,13 @@ class MissingPostControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("실종/보호 게시글 북마크 삭제 테스트")
     void deleteMissingPostBookmarkTest() throws Exception {
         // given
         // when
         ResultActions resultActions = mockMvc.perform(delete("/api/v1/missing-posts/{postId}/bookmark", 1L)
-            .header(HttpHeaders.AUTHORIZATION, JwtMockToken.MOCK_TOKEN));
+            .header(HttpHeaders.AUTHORIZATION, getAuthenticationToken()));
 
         // then
         resultActions

--- a/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
+++ b/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
@@ -12,6 +12,8 @@ import com.pet.domains.area.domain.City;
 import com.pet.domains.area.domain.Town;
 import com.pet.domains.area.repository.CityRepository;
 import com.pet.domains.area.repository.TownRepository;
+import com.pet.domains.auth.domain.Group;
+import com.pet.domains.auth.repository.GroupRepository;
 import com.pet.domains.post.domain.MissingPost;
 import com.pet.domains.post.domain.MissingPostBookmark;
 import com.pet.domains.post.domain.SexType;
@@ -34,6 +36,9 @@ import org.springframework.context.annotation.FilterType;
 class MissingPostBookmarkRepositoryTest {
 
     @Autowired
+    GroupRepository groupRepository;
+
+    @Autowired
     AccountRepository accountRepository;
 
     @Autowired
@@ -54,6 +59,8 @@ class MissingPostBookmarkRepositoryTest {
     @Autowired
     MissingPostBookmarkRepository missingPostBookmarkRepository;
 
+    private Group group;
+
     private Account account;
 
     private City city;
@@ -70,9 +77,14 @@ class MissingPostBookmarkRepositoryTest {
 
     @BeforeEach
     void setUp() {
+        group = new Group("name");
+        groupRepository.save(group);
+
         account = Account.builder()
             .nickname("nickname")
             .email("abvcd@naver.com")
+            .group(group)
+            .password("111111")
             .build();
         accountRepository.save(account);
 

--- a/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
+++ b/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
@@ -1,0 +1,154 @@
+package com.pet.domains.post.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import com.pet.common.config.JpaAuditingConfig;
+import com.pet.domains.account.domain.Account;
+import com.pet.domains.account.repository.AccountRepository;
+import com.pet.domains.animal.domain.Animal;
+import com.pet.domains.animal.domain.AnimalKind;
+import com.pet.domains.animal.repository.AnimalKindRepository;
+import com.pet.domains.animal.repository.AnimalRepository;
+import com.pet.domains.area.domain.City;
+import com.pet.domains.area.domain.Town;
+import com.pet.domains.area.repository.CityRepository;
+import com.pet.domains.area.repository.TownRepository;
+import com.pet.domains.post.domain.MissingPost;
+import com.pet.domains.post.domain.MissingPostBookmark;
+import com.pet.domains.post.domain.SexType;
+import com.pet.domains.post.domain.Status;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JpaAuditingConfig.class))
+@DisplayName("MissingPostBookmark RepositoryTest 테스트")
+class MissingPostBookmarkRepositoryTest {
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    CityRepository cityRepository;
+
+    @Autowired
+    TownRepository townRepository;
+
+    @Autowired
+    MissingPostRepository missingPostRepository;
+
+    @Autowired
+    AnimalRepository animalRepository;
+
+    @Autowired
+    AnimalKindRepository animalKindRepository;
+
+    @Autowired
+    MissingPostBookmarkRepository missingPostBookmarkRepository;
+
+    private Account account;
+
+    private City city;
+
+    private Town town;
+
+    private MissingPost missingPost;
+
+    private Animal animal;
+
+    private AnimalKind animalKind;
+
+    private MissingPostBookmark missingPostBookmark;
+
+    @BeforeEach
+    void setUp() {
+        account = Account.builder()
+            .nickname("nickname")
+            .email("abvcd@naver.com")
+            .build();
+        accountRepository.save(account);
+
+        city = City.builder()
+            .code("001")
+            .name("서울시")
+            .build();
+        cityRepository.save(city);
+
+        town = Town.builder()
+            .city(city)
+            .code("001")
+            .name("노원구")
+            .build();
+        townRepository.save(town);
+
+        animal = Animal.builder()
+            .code("001")
+            .name("강아지")
+            .build();
+        animalRepository.save(animal);
+
+        animalKind = AnimalKind.builder()
+            .code("001")
+            .name("푸들")
+            .animal(animal)
+            .build();
+        animalKindRepository.save(animalKind);
+
+        missingPost = MissingPost.builder()
+            .status(Status.DETECTION)
+            .detailAddress("상세주소")
+            .date(LocalDate.now())
+            .age(10L)
+            .sexType(SexType.MALE)
+            .chipNumber("010101003")
+            .content("content")
+            .telNumber("01033342231")
+            .viewCount(0)
+            .bookmarkCount(0)
+            .commentCount(0)
+            .thumbnail("asdfasdfsad.jpg")
+            .account(account)
+            .town(town)
+            .animalKind(animalKind)
+            .build();
+        missingPostRepository.save(missingPost);
+    }
+
+    @AfterEach
+    void tearDown() {
+        missingPostBookmarkRepository.deleteAll();
+        missingPostRepository.deleteAll();
+        animalKindRepository.deleteAll();
+        animalRepository.deleteAll();
+        townRepository.deleteAll();
+        cityRepository.deleteAll();
+        accountRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("실종/보호 게시물 북마크 삭제 테스트")
+    void deleteMissingPost() {
+        //given
+        missingPostBookmark = MissingPostBookmark.builder()
+            .missingPost(missingPost)
+            .account(account)
+            .build();
+        missingPostBookmarkRepository.save(missingPostBookmark);
+
+        //when
+        missingPostBookmarkRepository.deleteByMissingPostIdAndAccount(missingPost.getId(), account);
+
+        //then
+        List<MissingPostBookmark> getMissingPostBookmarks = missingPostBookmarkRepository.findAll();
+        assertThat(getMissingPostBookmarks.size()).isEqualTo(0);
+    }
+
+}

--- a/src/test/java/com/pet/domains/post/service/MissingPostBookmarkServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/MissingPostBookmarkServiceTest.java
@@ -3,9 +3,11 @@ package com.pet.domains.post.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import com.pet.domains.account.domain.Account;
 import com.pet.domains.post.domain.MissingPost;
 import com.pet.domains.post.domain.MissingPostBookmark;
 import com.pet.domains.post.repository.MissingPostBookmarkRepository;
@@ -46,6 +48,19 @@ class MissingPostBookmarkServiceTest {
         //then
         verify(missingPostRepository, times(1)).findById(anyLong());
         verify(missingPostBookmarkRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("실종/보호 게시물 북마크 삭제 테스트")
+    void deleteMissingPostBookmarkTest() {
+        //given
+        doNothing().when(missingPostBookmarkRepository).deleteByMissingPostIdAndAccount(anyLong(), any());
+
+        //when
+        missingPostBookmarkRepository.deleteByMissingPostIdAndAccount(1L, mock(Account.class));
+
+        //then
+        verify(missingPostBookmarkRepository, times(1)).deleteByMissingPostIdAndAccount(anyLong(), any());
     }
 
 }


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #190 

## 내용
- 설명 : 실종/보호 게시물 북마크 삭제 기능 추가

## 추가 및 변경 로직
- change

## 참고 및 기타
