### PR TITLE
[CP-176] 게시글 통계 데이터 cron job 추가

### DIFF
--- a/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
+++ b/src/main/java/com/pet/domains/post/dto/request/ShelterPostCreateParams.java
@@ -114,7 +114,11 @@ public class ShelterPostCreateParams {
             if (whileSpaceIdx == -1) {
                 return UNKNOWN;
             }
-            return StringUtils.substring(kindCd, whileSpaceIdx + 1).strip();
+            String splitName = StringUtils.substring(kindCd, whileSpaceIdx + 1);
+            if (StringUtils.isEmpty(splitName)) {
+                return UNKNOWN;
+            }
+            return splitName.strip();
         }
 
         public String getCityNameFromAddress() {

--- a/src/main/java/com/pet/domains/statistics/domain/PostStatistics.java
+++ b/src/main/java/com/pet/domains/statistics/domain/PostStatistics.java
@@ -12,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
@@ -43,6 +44,8 @@ public class PostStatistics extends BaseEntity {
 
     @Builder
     public PostStatistics(long missing, long detection, long protection, long completion, LocalDateTime date) {
+        Validate.notNull(date, "date must not be null");
+
         this.missing = missing;
         this.detection = detection;
         this.protection = protection;

--- a/src/main/java/com/pet/domains/statistics/domain/PostStatistics.java
+++ b/src/main/java/com/pet/domains/statistics/domain/PostStatistics.java
@@ -9,8 +9,11 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,4 +41,24 @@ public class PostStatistics extends BaseEntity {
     @Column(name = "date", nullable = false, updatable = false, columnDefinition = "TIMESTAMP")
     private LocalDateTime date;
 
+    @Builder
+    public PostStatistics(long missing, long detection, long protection, long completion, LocalDateTime date) {
+        this.missing = missing;
+        this.detection = detection;
+        this.protection = protection;
+        this.completion = completion;
+        this.date = date;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("id", id)
+            .append("missing", missing)
+            .append("detection", detection)
+            .append("protection", protection)
+            .append("completion", completion)
+            .append("date", date)
+            .toString();
+    }
 }

--- a/src/main/java/com/pet/domains/statistics/mapper/PostStatisticsMapper.java
+++ b/src/main/java/com/pet/domains/statistics/mapper/PostStatisticsMapper.java
@@ -1,0 +1,28 @@
+package com.pet.domains.statistics.mapper;
+
+import com.pet.domains.post.domain.Status;
+import com.pet.domains.statistics.domain.PostStatistics;
+import com.pet.domains.statistics.repository.PostCountByStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PostStatisticsMapper {
+
+    default PostStatistics toEntity(List<PostCountByStatus> postCountByStatuses, LocalDateTime now) {
+        Map<Status, Long> statusLongMap = postCountByStatuses.stream()
+            .collect(Collectors.toMap(PostCountByStatus::getPostStatus, PostCountByStatus::getCount));
+
+        return PostStatistics.builder()
+            .missing(statusLongMap.getOrDefault(Status.MISSING, 0L))
+            .protection(statusLongMap.getOrDefault(Status.PROTECTION, 0L))
+            .detection(statusLongMap.getOrDefault(Status.DETECTION, 0L))
+            .completion(statusLongMap.getOrDefault(Status.COMPLETION, 0L))
+            .date(now)
+            .build();
+    }
+
+}

--- a/src/main/java/com/pet/domains/statistics/repository/PostCountByStatus.java
+++ b/src/main/java/com/pet/domains/statistics/repository/PostCountByStatus.java
@@ -1,0 +1,11 @@
+package com.pet.domains.statistics.repository;
+
+import com.pet.domains.post.domain.Status;
+
+public interface PostCountByStatus {
+
+    Status getPostStatus();
+
+    long getCount();
+
+}

--- a/src/main/java/com/pet/domains/statistics/repository/PostStatisticsRepository.java
+++ b/src/main/java/com/pet/domains/statistics/repository/PostStatisticsRepository.java
@@ -1,0 +1,13 @@
+package com.pet.domains.statistics.repository;
+
+import com.pet.domains.statistics.domain.PostStatistics;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PostStatisticsRepository extends JpaRepository<PostStatistics, Long> {
+
+    @Query("SELECT mp.status AS postStatus, count(mp) AS count FROM MissingPost AS mp GROUP BY mp.status")
+    List<PostCountByStatus> findGroupByStatus();
+
+}

--- a/src/main/java/com/pet/domains/statistics/repository/PostStatisticsRepository.java
+++ b/src/main/java/com/pet/domains/statistics/repository/PostStatisticsRepository.java
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PostStatisticsRepository extends JpaRepository<PostStatistics, Long> {
 
-    @Query("SELECT mp.status AS postStatus, count(mp) AS count FROM MissingPost AS mp WHERE mp.deleted=false GROUP BY mp.status")
+    @Query("SELECT mp.status AS postStatus, count(mp) AS count FROM"
+        + " MissingPost AS mp WHERE mp.deleted=false GROUP BY mp.status")
     List<PostCountByStatus> findGroupByStatus();
 
 }

--- a/src/main/java/com/pet/domains/statistics/repository/PostStatisticsRepository.java
+++ b/src/main/java/com/pet/domains/statistics/repository/PostStatisticsRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PostStatisticsRepository extends JpaRepository<PostStatistics, Long> {
 
-    @Query("SELECT mp.status AS postStatus, count(mp) AS count FROM MissingPost AS mp GROUP BY mp.status")
+    @Query("SELECT mp.status AS postStatus, count(mp) AS count FROM MissingPost AS mp WHERE mp.deleted=false GROUP BY mp.status")
     List<PostCountByStatus> findGroupByStatus();
 
 }

--- a/src/main/java/com/pet/domains/statistics/service/PostStatisticsService.java
+++ b/src/main/java/com/pet/domains/statistics/service/PostStatisticsService.java
@@ -1,0 +1,34 @@
+package com.pet.domains.statistics.service;
+
+import com.pet.domains.statistics.domain.PostStatistics;
+import com.pet.domains.statistics.mapper.PostStatisticsMapper;
+import com.pet.domains.statistics.repository.PostCountByStatus;
+import com.pet.domains.statistics.repository.PostStatisticsRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class PostStatisticsService {
+
+    private final PostStatisticsRepository postStatisticsRepository;
+
+    private final PostStatisticsMapper postStatisticsMapper;
+
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void createPostStatistics() {
+        LocalDateTime now = LocalDateTime.now();
+        List<PostCountByStatus> groupByStatus = postStatisticsRepository.findGroupByStatus();
+        PostStatistics postStatistics = postStatisticsRepository.save(postStatisticsMapper.toEntity(groupByStatus, now));
+        log.info("{} created at {}", postStatistics, postStatistics.getDate());
+    }
+
+}

--- a/src/main/java/com/pet/domains/statistics/service/PostStatisticsService.java
+++ b/src/main/java/com/pet/domains/statistics/service/PostStatisticsService.java
@@ -27,7 +27,8 @@ public class PostStatisticsService {
     public void createPostStatistics() {
         LocalDateTime now = LocalDateTime.now();
         List<PostCountByStatus> groupByStatus = postStatisticsRepository.findGroupByStatus();
-        PostStatistics postStatistics = postStatisticsRepository.save(postStatisticsMapper.toEntity(groupByStatus, now));
+        PostStatistics postStatistics = postStatisticsRepository.save(
+            postStatisticsMapper.toEntity(groupByStatus, now));
         log.info("{} created at {}", postStatistics, postStatistics.getDate());
     }
 

--- a/src/test/java/com/pet/domains/statistics/service/PostStatisticsServicesTest.java
+++ b/src/test/java/com/pet/domains/statistics/service/PostStatisticsServicesTest.java
@@ -1,0 +1,62 @@
+package com.pet.domains.statistics.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import com.pet.domains.statistics.domain.PostStatistics;
+import com.pet.domains.statistics.mapper.PostStatisticsMapper;
+import com.pet.domains.statistics.repository.PostCountByStatus;
+import com.pet.domains.statistics.repository.PostStatisticsRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostStatisticsServicesTest {
+
+    @Mock
+    private PostStatisticsRepository postStatisticsRepository;
+
+    @Mock
+    private PostStatisticsMapper postStatisticsMapper;
+
+    @InjectMocks
+    private PostStatisticsService postStatisticsService;
+
+    @Test
+    @DisplayName("게시글 통계 성공 테스트")
+    void createPostStatisticsSuccess() {
+        // given
+        PostStatistics postStatistics = PostStatistics.builder()
+            .missing(1L)
+            .completion(2L)
+            .detection(3L)
+            .protection(4L)
+            .date(LocalDateTime.now())
+            .build();
+
+        given(postStatisticsRepository.findGroupByStatus()).willReturn(List.of(mock(PostCountByStatus.class)));
+        given(postStatisticsMapper.toEntity(anyList(), any(LocalDateTime.class))).willReturn(postStatistics);
+        given(postStatisticsRepository.save(any(PostStatistics.class))).willReturn(postStatistics);
+
+        // when
+        postStatisticsService.createPostStatistics();
+
+        // then
+        ArgumentCaptor<PostStatistics> captor = ArgumentCaptor.forClass(PostStatistics.class);
+        verify(postStatisticsRepository, times(1)).findGroupByStatus();
+        verify(postStatisticsRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getCompletion()).isEqualTo(postStatistics.getCompletion());
+    }
+
+}


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #176 

## 내용
- 설명 : 게시글 통계 데이터 cron job 추가

## 추가 및 변경 로직
- open api 데이터 중 [고양이] 공백 요러케 들어오는 경우도 있는 것 같습니다.

## 참고 및 기타
