### PR TITLE
[CP-220] feat: 권한이 필요한 요청에 토큰을 넣지 않는 경우 처리

### DIFF
--- a/src/main/java/com/pet/common/config/SecurityConfig.java
+++ b/src/main/java/com/pet/common/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -28,6 +29,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+import static org.springframework.http.HttpMethod.*;
 
 @Configuration
 @RequiredArgsConstructor
@@ -90,7 +92,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
 
             // 보호소 게시글
-            .antMatchers(v1("/shelter-posts")).hasAnyRole(ROLE_USER, ROLE_ANONYMOUS)
+            .antMatchers(GET, v1("/shelter-posts")).hasAnyRole(ROLE_USER, ROLE_ANONYMOUS)
 
             // 회원, 알림
             .antMatchers(v1("/me/**"), v1("/auth-user"), v1("/notices/**")).hasAnyRole(ROLE_USER)

--- a/src/main/java/com/pet/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/pet/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.pet.common.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pet.common.response.ErrorResponse;
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import static com.pet.common.exception.ExceptionMessage.*;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authEx)
+        throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        ExceptionMessage notFoundJwt = NOT_FOUND_JWT;
+        response.getWriter().write(objectMapper.writeValueAsString(
+            ErrorResponse.error(ExceptionMessage.getCode(notFoundJwt), notFoundJwt.getException().getMessage())
+        ));
+    }
+
+}

--- a/src/main/java/com/pet/common/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/pet/common/exception/ExceptionHandlerAdvice.java
@@ -3,6 +3,7 @@ package com.pet.common.exception;
 import com.pet.common.exception.httpexception.AuthenticationException;
 import com.pet.common.exception.httpexception.BadRequestException;
 import com.pet.common.exception.httpexception.ConflictException;
+import com.pet.common.exception.httpexception.ForbiddenException;
 import com.pet.common.exception.httpexception.NotFoundException;
 import com.pet.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -29,12 +30,6 @@ public class ExceptionHandlerAdvice {
         return ErrorResponse.error(HttpStatus.BAD_REQUEST.value(), exception.getMessage());
     }
 
-    @ExceptionHandler(ConflictException.class)
-    @ResponseStatus(HttpStatus.CONFLICT)
-    public ErrorResponse handleConflictException(ConflictException exception) {
-        return ErrorResponse.error(exception.getCode(), exception.getMessage());
-    }
-
     @ExceptionHandler(NotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNotFoundException(NotFoundException exception) {
@@ -46,6 +41,19 @@ public class ExceptionHandlerAdvice {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ErrorResponse handleUnauthorizedException(AuthenticationException exception) {
         log.warn(exception.getMessage());
+        return ErrorResponse.error(exception.getCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ErrorResponse handleForbiddenException(ForbiddenException exception) {
+        log.warn(exception.getMessage());
+        return ErrorResponse.error(exception.getCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleConflictException(ConflictException exception) {
         return ErrorResponse.error(exception.getCode(), exception.getMessage());
     }
 

--- a/src/main/java/com/pet/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/pet/common/exception/ExceptionMessage.java
@@ -4,6 +4,7 @@ import com.pet.common.exception.httpexception.AuthenticationException;
 import com.pet.common.exception.httpexception.BadRequestException;
 import com.pet.common.exception.httpexception.BaseHttpException;
 import com.pet.common.exception.httpexception.ConflictException;
+import com.pet.common.exception.httpexception.ForbiddenException;
 import com.pet.common.exception.httpexception.InternalServerException;
 import com.pet.common.exception.httpexception.NotFoundException;
 import lombok.Getter;
@@ -12,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ExceptionMessage {
+    // 인가
+    UN_IDENTIFICATION(new ForbiddenException("권한이 없습니다", 403)),
+
     // 서버 관련
     INTERNAL_SERVER(new InternalServerException("서버 에러입니다. 서버 관리자에게 문의주세요.", 500)),
 
@@ -31,14 +35,14 @@ public enum ExceptionMessage {
     NOT_FOUND_CITY(new NotFoundException("해당하는 시도 지역을 찾을 수 없습니다.", 801)),
     NOT_FOUND_TOWN(new NotFoundException("해당하는 시군구 지역을 찾을 수 없습니다.", 802)),
 
-    // 인증 9xx
+    // 인증 9xx,
     SHOULD_LOGIN(new AuthenticationException("로그인이 필요합니다.", 901)),
     INVALID_LOGIN(new AuthenticationException("로그인에 실패했습니다.", 902)),
     INVALID_JWT(new AuthenticationException("유효하지 않은 토큰입니다.", 903)),
     INVALID_JWT_EXPIRY(new AuthenticationException("토큰이 만료되었습니다.", 904)),
     NOT_FOUND_GROUP(new AuthenticationException("존재하지 않는 그룹입니다.", 905)),
     NOT_FOUND_PROVIDER(new AuthenticationException("지원하지 않는 인증 방식입니다.", 906)),
-    UN_IDENTIFICATION(new AuthenticationException("본인이 아닙니다.", 907)),
+    NOT_FOUND_JWT(new AuthenticationException("토큰이 필요합니다.", 907)),
 
     // 댓글 10xx
     NOT_FOUND_COMMENT(new NotFoundException("해당하는 댓글을 찾을 수 없습니다.", 1001)),

--- a/src/main/java/com/pet/common/exception/httpexception/ForbiddenException.java
+++ b/src/main/java/com/pet/common/exception/httpexception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.pet.common.exception.httpexception;
+
+public class ForbiddenException extends BaseHttpException {
+
+    public ForbiddenException(String message, int code) {
+        super(message, code);
+    }
+
+}

--- a/src/test/java/com/pet/domains/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/pet/domains/account/controller/AccountControllerTest.java
@@ -325,6 +325,7 @@ class AccountControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("회원 게시물 조회")
     void getAccountMissingPostsTest() throws Exception {
         // given
@@ -366,6 +367,7 @@ class AccountControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("회원 북마크(실종/보호) 조회")
     void getAccountMissingBookmarkPostTest() throws Exception {
         // given
@@ -406,6 +408,7 @@ class AccountControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("회원 북마크(보호소) 조회")
     void getAccountShelterBookmarkPostTest() throws Exception {
         // given
@@ -446,6 +449,7 @@ class AccountControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("회원 탈퇴 테스트")
     void deleteAccount() throws Exception {
         // given

--- a/src/test/java/com/pet/domains/account/controller/NotificationControllerTest.java
+++ b/src/test/java/com/pet/domains/account/controller/NotificationControllerTest.java
@@ -19,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.pet.domains.account.WithAccount;
 import com.pet.domains.account.dto.request.NotificationUpdateParam;
 import com.pet.domains.docs.BaseDocumentationTest;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +32,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class NotificationControllerTest extends BaseDocumentationTest {
 
     @Test
+    @WithAccount
     @DisplayName("알림 조회 요청 테스트")
     void getNotificationTest() throws Exception {
         // given
@@ -61,11 +63,13 @@ class NotificationControllerTest extends BaseDocumentationTest {
     }
 
     @Test
+    @WithAccount
     @DisplayName("알림 삭제 요청 테스트")
     void deleteNotificationTest() throws Exception {
         // given
         // when
-        ResultActions resultActions = mockMvc.perform(delete("/api/v1/notices/{noticeId}", 1L));
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/notices/{noticeId}", 1L)
+            .header(HttpHeaders.AUTHORIZATION, getAuthenticationToken()));
 
         // then
         resultActions
@@ -73,11 +77,15 @@ class NotificationControllerTest extends BaseDocumentationTest {
             .andExpect(status().isNoContent())
             .andDo(document("delete-notification",
                 preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()))
-            );
+                preprocessResponse(prettyPrint()),
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("jwt token")
+                )
+            ));
     }
 
     @Test
+    @WithAccount
     @DisplayName("알림 상태 변경 요청 테스트")
     void checkedNotificationTest() throws Exception {
         // given
@@ -85,7 +93,8 @@ class NotificationControllerTest extends BaseDocumentationTest {
         // when
         ResultActions resultActions = mockMvc.perform(patch("/api/v1/notices/{noticeId}", 1L)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(param)));
+            .content(objectMapper.writeValueAsString(param))
+            .header(HttpHeaders.AUTHORIZATION, getAuthenticationToken()));
 
         // then
         resultActions
@@ -95,6 +104,7 @@ class NotificationControllerTest extends BaseDocumentationTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("jwt token"),
                     headerWithName(HttpHeaders.CONTENT_TYPE).description(MediaType.APPLICATION_JSON_VALUE)
                 ),
                 requestFields(


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #220 

## 내용
- 설명: 기존 코드는 토큰을 넣지 않는 경우 LoginAccount가 null로 잡히면서 NPE로 인해 500에러가 나갔습니다.
entryPoint가 여기서 필요한거였어요. 토큰이 필요한 api라면 antMatcher에 url을 추가해주세요. 익명도 허용하는 곳이라면 기존 케빈이 작성했던것처럼
익명권한도 추가해주면 됩니다.

<img width="970" alt="스크린샷 2021-12-16 오전 1 59 34" src="https://user-images.githubusercontent.com/58363663/146230834-52a1c89b-5899-4690-9f48-2fe48100102b.png">

## 추가 및 변경 로직
- change

## 참고 및 기타
