### PR TITLE
[CP-280] 댓글 생성, 수정시 바디 리턴

### DIFF
--- a/src/main/java/com/pet/domains/comment/controller/CommentController.java
+++ b/src/main/java/com/pet/domains/comment/controller/CommentController.java
@@ -6,7 +6,6 @@ import com.pet.domains.account.domain.LoginAccount;
 import com.pet.domains.comment.dto.request.CommentCreateParam;
 import com.pet.domains.comment.dto.request.CommentUpdateParam;
 import com.pet.domains.comment.service.CommentService;
-import java.util.Map;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,9 +37,7 @@ public class CommentController {
         @LoginAccount Account account,
         @RequestBody @Valid CommentCreateParam commentCreateParam
     ) {
-        return ApiResponse.ok(
-            Map.of("id", commentService.createComment(account, commentCreateParam))
-        );
+        return ApiResponse.ok(commentService.createComment(account, commentCreateParam));
     }
 
     @ResponseStatus(HttpStatus.OK)
@@ -54,7 +51,7 @@ public class CommentController {
         @RequestBody @Valid CommentUpdateParam commentUpdateParam,
         @LoginAccount Account account
     ) {
-        return ApiResponse.ok(Map.of("id", commentService.updateComment(commentId, commentUpdateParam, account)));
+        return ApiResponse.ok(commentService.updateComment(commentId, commentUpdateParam, account));
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/pet/domains/comment/dto/response/CommentWriteResult.java
+++ b/src/main/java/com/pet/domains/comment/dto/response/CommentWriteResult.java
@@ -1,0 +1,65 @@
+package com.pet.domains.comment.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CommentWriteResult {
+
+    private long id;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private Account account;
+
+    private List<ChildComment> childComments;
+
+    public CommentWriteResult(long id, String content, LocalDateTime createdAt,
+        Account account,
+        List<ChildComment> childComments) {
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.account = account;
+        this.childComments = childComments;
+    }
+
+    @Getter
+    public static class Account {
+
+        private long id;
+
+        private String nickname;
+
+        private String image;
+
+        public Account(long id, String nickname, String image) {
+            this.id = id;
+            this.nickname = nickname;
+            this.image = image;
+        }
+    }
+
+    @Getter
+    public static class ChildComment {
+
+        private long id;
+
+        private String content;
+
+        private LocalDateTime createdAt;
+
+        private Account account;
+
+        public ChildComment(long id, String content, LocalDateTime createdAt,
+            Account account) {
+            this.id = id;
+            this.content = content;
+            this.createdAt = createdAt;
+            this.account = account;
+        }
+    }
+}

--- a/src/main/java/com/pet/domains/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/pet/domains/comment/mapper/CommentMapper.java
@@ -3,6 +3,7 @@ package com.pet.domains.comment.mapper;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.comment.domain.Comment;
 import com.pet.domains.comment.dto.response.CommentPageResults;
+import com.pet.domains.comment.dto.response.CommentWriteResult;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -12,9 +13,9 @@ import org.springframework.data.domain.Page;
 public interface CommentMapper {
 
     @Mapping(target = "image", source = "account.image.name")
-    CommentPageResults.Comment.Account toAccountResult(Account account);
+    CommentPageResults.Comment.Account toAccountReadResult(Account account);
 
-    List<CommentPageResults.Comment.ChildComment> toChildCommentResults(List<Comment> childComments);
+    List<CommentPageResults.Comment.ChildComment> toChildCommentReadResults(List<Comment> childComments);
 
     List<CommentPageResults.Comment> toCommentResult(List<Comment> comments);
 
@@ -26,5 +27,13 @@ public interface CommentMapper {
             commentPage.getSize()
         );
     }
+
+    List<CommentWriteResult.ChildComment> toChildCommentWriteResults(List<Comment> childComments);
+
+    @Mapping(target = "image", source = "account.image.name")
+    CommentWriteResult.Account toAccountWriteResult(Account account);
+
+    CommentWriteResult toCommentWriteResult(Comment comment);
+
 
 }

--- a/src/main/java/com/pet/domains/comment/service/CommentService.java
+++ b/src/main/java/com/pet/domains/comment/service/CommentService.java
@@ -7,6 +7,7 @@ import com.pet.domains.comment.domain.Comment;
 import com.pet.domains.comment.dto.request.CommentCreateParam;
 import com.pet.domains.comment.dto.request.CommentUpdateParam;
 import com.pet.domains.comment.dto.response.CommentPageResults;
+import com.pet.domains.comment.dto.response.CommentWriteResult;
 import com.pet.domains.comment.mapper.CommentMapper;
 import com.pet.domains.comment.repository.CommentRepository;
 import com.pet.domains.post.domain.MissingPost;
@@ -35,21 +36,24 @@ public class CommentService {
     }
 
     @Transactional
-    public Long createComment(Account account, CommentCreateParam commentCreateParam) {
+    public CommentWriteResult createComment(Account account, CommentCreateParam commentCreateParam) {
         MissingPost missingPost = getMissingPostById(commentCreateParam.getPostId());
         OptimisticLockingHandlingUtils.handling(
             missingPost::increaseCommentCount,
             5,
             "실종 게시글 댓글 카운트 증가"
         );
-        return commentRepository.save(getNewComment(account, commentCreateParam, missingPost)).getId();
+        return commentMapper.toCommentWriteResult(
+            commentRepository.save(getNewComment(account, commentCreateParam, missingPost))
+        );
     }
 
     @Transactional
-    public Long updateComment(Long commentId, CommentUpdateParam commentUpdateParam, Account account) {
+    public CommentWriteResult updateComment(Long commentId, CommentUpdateParam commentUpdateParam, Account account) {
         Comment foundComment = getMyComment(commentId, account);
         foundComment.updateContent(commentUpdateParam.getContent(), account.getId());
-        return foundComment.getId();
+
+        return commentMapper.toCommentWriteResult(foundComment);
     }
 
     @Transactional

--- a/src/test/java/com/pet/domains/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/pet/domains/comment/controller/CommentControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -26,7 +27,10 @@ import com.pet.domains.account.WithAccount;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.comment.dto.request.CommentCreateParam;
 import com.pet.domains.comment.dto.request.CommentUpdateParam;
+import com.pet.domains.comment.dto.response.CommentWriteResult;
 import com.pet.domains.docs.BaseDocumentationTest;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -41,12 +45,24 @@ class CommentControllerTest extends BaseDocumentationTest {
     @DisplayName("댓글 생성 테스트")
     void createCommentTest() throws Exception {
         // given
-        given(commentService.createComment(any(Account.class), any(CommentCreateParam.class))).willReturn(1L);
         CommentCreateParam createParam = CommentCreateParam.builder()
             .postId(1L)
             .content("content")
             .parentCommentId(13L)
             .build();
+        CommentWriteResult createResult = new CommentWriteResult(
+            123L,
+            createParam.getContent(),
+            LocalDateTime.now(),
+            new CommentWriteResult.Account(12L, "회원", "http://../.jpg"),
+            List.of(new CommentWriteResult.ChildComment(
+                13L,
+                "자식 댓글",
+                LocalDateTime.now(),
+                new CommentWriteResult.Account(154L, "대댓글 회원", "http://../.jpg"))
+            )
+        );
+        given(commentService.createComment(any(Account.class), any(CommentCreateParam.class))).willReturn(createResult);
 
         // when
         ResultActions resultActions = mockMvc.perform(post("/api/v1/comments")
@@ -76,6 +92,22 @@ class CommentControllerTest extends BaseDocumentationTest {
                 responseFields(
                     fieldWithPath("data").type(OBJECT).description("응답 데이터"),
                     fieldWithPath("data.id").type(NUMBER).description("댓글 아이디"),
+                    fieldWithPath("data.content").type(STRING).description("댓글 내용"),
+                    fieldWithPath("data.createdAt").type(STRING).description("댓글 작성날짜"),
+                    fieldWithPath("data.account").type(OBJECT).description("댓글 작성자"),
+                    fieldWithPath("data.account.id").type(NUMBER).description("작성자 아이디"),
+                    fieldWithPath("data.account.nickname").type(STRING).description("작성자 닉네임"),
+                    fieldWithPath("data.account.image").type(STRING).description("작성자 프로필 사진"),
+                    fieldWithPath("data.childComments").type(ARRAY).description("댓글의 대댓글 목록"),
+                    fieldWithPath("data.childComments[].id").type(NUMBER).description("대댓글 아이디"),
+                    fieldWithPath("data.childComments[].content").type(STRING).description("대댓글 내용"),
+                    fieldWithPath("data.childComments[].createdAt").type(STRING).description("대댓글 작성날짜"),
+                    fieldWithPath("data.childComments[].account").type(OBJECT).description("대댓글 작성자"),
+                    fieldWithPath("data.childComments[].account.id").type(NUMBER).description("작성자 아이디"),
+                    fieldWithPath("data.childComments[].account.nickname").type(STRING)
+                        .description("작성자 닉네임"),
+                    fieldWithPath("data.childComments[].account.image").type(STRING)
+                        .description("작성자 프로필 사진"),
                     fieldWithPath("serverDateTime").type(STRING).description("서버 응답 시간")))
             );
     }
@@ -85,11 +117,23 @@ class CommentControllerTest extends BaseDocumentationTest {
     @DisplayName("댓글 수정 테스트")
     void updateCommentTest() throws Exception {
         // given
-        given(commentService.updateComment(anyLong(), any(CommentUpdateParam.class), any(Account.class)))
-            .willReturn(1L);
         CommentUpdateParam updateParam = CommentUpdateParam.builder()
             .content("updated content")
             .build();
+        CommentWriteResult updateResult = new CommentWriteResult(
+            123L,
+            updateParam.getContent(),
+            LocalDateTime.now(),
+            new CommentWriteResult.Account(12L, "회원", "http://../.jpg"),
+            List.of(new CommentWriteResult.ChildComment(
+                13L,
+                "자식 댓글",
+                LocalDateTime.now(),
+                new CommentWriteResult.Account(154L, "대댓글 회원", "http://../.jpg"))
+            )
+        );
+        given(commentService.updateComment(anyLong(), any(CommentUpdateParam.class), any(Account.class)))
+            .willReturn(updateResult);
 
         // when
         ResultActions resultActions = mockMvc.perform(patch("/api/v1/comments/{commentId}", 1L)
@@ -120,6 +164,22 @@ class CommentControllerTest extends BaseDocumentationTest {
                 responseFields(
                     fieldWithPath("data").type(OBJECT).description("응답 데이터"),
                     fieldWithPath("data.id").type(NUMBER).description("댓글 아이디"),
+                    fieldWithPath("data.content").type(STRING).description("댓글 내용"),
+                    fieldWithPath("data.createdAt").type(STRING).description("댓글 작성날짜"),
+                    fieldWithPath("data.account").type(OBJECT).description("댓글 작성자"),
+                    fieldWithPath("data.account.id").type(NUMBER).description("작성자 아이디"),
+                    fieldWithPath("data.account.nickname").type(STRING).description("작성자 닉네임"),
+                    fieldWithPath("data.account.image").type(STRING).description("작성자 프로필 사진"),
+                    fieldWithPath("data.childComments").type(ARRAY).description("댓글의 대댓글 목록"),
+                    fieldWithPath("data.childComments[].id").type(NUMBER).description("대댓글 아이디"),
+                    fieldWithPath("data.childComments[].content").type(STRING).description("대댓글 내용"),
+                    fieldWithPath("data.childComments[].createdAt").type(STRING).description("대댓글 작성날짜"),
+                    fieldWithPath("data.childComments[].account").type(OBJECT).description("대댓글 작성자"),
+                    fieldWithPath("data.childComments[].account.id").type(NUMBER).description("작성자 아이디"),
+                    fieldWithPath("data.childComments[].account.nickname").type(STRING)
+                        .description("작성자 닉네임"),
+                    fieldWithPath("data.childComments[].account.image").type(STRING)
+                        .description("작성자 프로필 사진"),
                     fieldWithPath("serverDateTime").type(STRING).description("서버 응답 시간")))
             );
     }


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #280 

## 내용
- 설명 : 프론트분들의 요청에 따라 댓글 생성 수정시 응답 바디에 내용을 담도록 수정입니다!

## 추가 및 변경 로직
- change

## 참고 및 기타
