### PR TITLE
[CP-289] 댓글 응답에 deleted 필드 추가

### DIFF
--- a/src/main/java/com/pet/domains/comment/dto/response/CommentPageResults.java
+++ b/src/main/java/com/pet/domains/comment/dto/response/CommentPageResults.java
@@ -35,14 +35,17 @@ public class CommentPageResults {
 
         private List<ChildComment> childComments;
 
+        private boolean deleted;
+
         public Comment(long id, String content, LocalDateTime createdAt,
             Account account,
-            List<ChildComment> childComments) {
+            List<ChildComment> childComments, boolean deleted) {
             this.id = id;
             this.content = content;
             this.createdAt = createdAt;
             this.account = account;
             this.childComments = childComments;
+            this.deleted = deleted;
         }
 
         @Getter

--- a/src/main/java/com/pet/domains/comment/dto/response/CommentWriteResult.java
+++ b/src/main/java/com/pet/domains/comment/dto/response/CommentWriteResult.java
@@ -17,14 +17,16 @@ public class CommentWriteResult {
 
     private List<ChildComment> childComments;
 
+    private boolean deleted;
+
     public CommentWriteResult(long id, String content, LocalDateTime createdAt,
-        Account account,
-        List<ChildComment> childComments) {
+        Account account, List<ChildComment> childComments, boolean deleted) {
         this.id = id;
         this.content = content;
         this.createdAt = createdAt;
         this.account = account;
         this.childComments = childComments;
+        this.deleted = deleted;
     }
 
     @Getter

--- a/src/test/java/com/pet/domains/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/pet/domains/comment/controller/CommentControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
@@ -60,7 +61,8 @@ class CommentControllerTest extends BaseDocumentationTest {
                 "자식 댓글",
                 LocalDateTime.now(),
                 new CommentWriteResult.Account(154L, "대댓글 회원", "http://../.jpg"))
-            )
+            ),
+            false
         );
         given(commentService.createComment(any(Account.class), any(CommentCreateParam.class))).willReturn(createResult);
 
@@ -94,6 +96,7 @@ class CommentControllerTest extends BaseDocumentationTest {
                     fieldWithPath("data.id").type(NUMBER).description("댓글 아이디"),
                     fieldWithPath("data.content").type(STRING).description("댓글 내용"),
                     fieldWithPath("data.createdAt").type(STRING).description("댓글 작성날짜"),
+                    fieldWithPath("data.deleted").type(BOOLEAN).description("삭제된 댓글 여부"),
                     fieldWithPath("data.account").type(OBJECT).description("댓글 작성자"),
                     fieldWithPath("data.account.id").type(NUMBER).description("작성자 아이디"),
                     fieldWithPath("data.account.nickname").type(STRING).description("작성자 닉네임"),
@@ -130,7 +133,8 @@ class CommentControllerTest extends BaseDocumentationTest {
                 "자식 댓글",
                 LocalDateTime.now(),
                 new CommentWriteResult.Account(154L, "대댓글 회원", "http://../.jpg"))
-            )
+            ),
+            false
         );
         given(commentService.updateComment(anyLong(), any(CommentUpdateParam.class), any(Account.class)))
             .willReturn(updateResult);
@@ -166,6 +170,7 @@ class CommentControllerTest extends BaseDocumentationTest {
                     fieldWithPath("data.id").type(NUMBER).description("댓글 아이디"),
                     fieldWithPath("data.content").type(STRING).description("댓글 내용"),
                     fieldWithPath("data.createdAt").type(STRING).description("댓글 작성날짜"),
+                    fieldWithPath("data.deleted").type(BOOLEAN).description("삭제된 댓글 여부"),
                     fieldWithPath("data.account").type(OBJECT).description("댓글 작성자"),
                     fieldWithPath("data.account.id").type(NUMBER).description("작성자 아이디"),
                     fieldWithPath("data.account.nickname").type(STRING).description("작성자 닉네임"),

--- a/src/test/java/com/pet/domains/post/controller/MissingPostControllerTest.java
+++ b/src/test/java/com/pet/domains/post/controller/MissingPostControllerTest.java
@@ -147,16 +147,16 @@ class MissingPostControllerTest extends BaseDocumentationTest {
     void getMissingPostsTest() throws Exception {
         //given
         MissingPostReadResults missingPostReadResults = MissingPostReadResults.of(List.of(
-                MissingPost.of(
-                    1L, "서울특별시", "도봉구", "토이푸들", Status.DETECTION, LocalDateTime.now(),
-                    SexType.FEMALE, true, 2,
-                    "https://post-phinf.pstatic.net/MjAyMTA0MTJfNTAg/MDAxNjE4MjMwNjg1MTEw",
-                    List.of(
-                        MissingPost.Tag.of(1L, "고슴도치"),
-                        MissingPost.Tag.of(2L, "애완동물"),
-                        MissingPost.Tag.of(3L, "반려동물")
-                    )
-                )),
+            MissingPost.of(
+                1L, "서울특별시", "도봉구", "토이푸들", Status.DETECTION, LocalDateTime.now(),
+                SexType.FEMALE, true, 2,
+                "https://post-phinf.pstatic.net/MjAyMTA0MTJfNTAg/MDAxNjE4MjMwNjg1MTEw",
+                List.of(
+                    MissingPost.Tag.of(1L, "고슴도치"),
+                    MissingPost.Tag.of(2L, "애완동물"),
+                    MissingPost.Tag.of(3L, "반려동물")
+                )
+            )),
             10,
             true,
             5
@@ -427,16 +427,17 @@ class MissingPostControllerTest extends BaseDocumentationTest {
         // given
         CommentPageResults commentPageResults = new CommentPageResults(
             LongStream.rangeClosed(1, 2).mapToObj(idx -> new CommentPageResults.Comment(
-                    idx,
-                    "부모 댓글 #" + idx,
+                idx,
+                "부모 댓글 #" + idx,
+                LocalDateTime.now(),
+                new Comment.Account(idx, "회원#" + idx, "http://../.jpg"),
+                List.of(new ChildComment(
+                    idx * 3,
+                    "자식 댓글 #" + idx * 3,
                     LocalDateTime.now(),
-                    new Comment.Account(idx, "회원#" + idx, "http://../.jpg"),
-                    List.of(new ChildComment(
-                        idx * 3,
-                        "자식 댓글 #" + idx * 3,
-                        LocalDateTime.now(),
-                        new Comment.Account(idx * 3, "회원#" + idx * 3, "http://../.jpg"))
-                    )))
+                    new Comment.Account(idx * 3, "회원#" + idx * 3, "http://../.jpg"))
+                ),
+                false))
                 .collect(Collectors.toList()),
             2,
             true,
@@ -470,6 +471,7 @@ class MissingPostControllerTest extends BaseDocumentationTest {
                     fieldWithPath("data.comments[].id").type(NUMBER).description("댓글 아이디"),
                     fieldWithPath("data.comments[].content").type(STRING).description("댓글 내용"),
                     fieldWithPath("data.comments[].createdAt").type(STRING).description("댓글 작성날짜"),
+                    fieldWithPath("data.comments[].deleted").type(BOOLEAN).description("삭제된 댓글 여부"),
                     fieldWithPath("data.comments[].account").type(OBJECT).description("댓글 작성자"),
                     fieldWithPath("data.comments[].account.id").type(NUMBER).description("작성자 아이디"),
                     fieldWithPath("data.comments[].account.nickname").type(STRING).description("작성자 닉네임"),


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #289 

## 내용
- 설명 : 프론트분이 요청하셔서 댓글 응답에 deleted 필드 추가 했습니다.

## 추가 및 변경 로직
- change

## 참고 및 기타
