### PR TITLE
[CP-287] 댓글, 북마크, 태그 카운트는 formula 사용 & 조회수만 낙관적 락 처리

### DIFF
--- a/src/main/java/com/pet/common/exception/ExceptionHandlerAdvice.java
+++ b/src/main/java/com/pet/common/exception/ExceptionHandlerAdvice.java
@@ -4,6 +4,7 @@ import com.pet.common.exception.httpexception.AuthenticationException;
 import com.pet.common.exception.httpexception.BadRequestException;
 import com.pet.common.exception.httpexception.ConflictException;
 import com.pet.common.exception.httpexception.ForbiddenException;
+import com.pet.common.exception.httpexception.InternalServerException;
 import com.pet.common.exception.httpexception.NotFoundException;
 import com.pet.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -73,6 +74,12 @@ public class ExceptionHandlerAdvice {
     @ExceptionHandler(ConflictException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ErrorResponse handleConflictException(ConflictException exception) {
+        return ErrorResponse.error(exception.getCode(), exception.getMessage());
+    }
+
+    @ExceptionHandler(InternalServerException.class)
+    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+    public ErrorResponse handleInternalServerException(InternalServerException exception) {
         return ErrorResponse.error(exception.getCode(), exception.getMessage());
     }
 

--- a/src/main/java/com/pet/common/exception/ExceptionMessage.java
+++ b/src/main/java/com/pet/common/exception/ExceptionMessage.java
@@ -18,6 +18,7 @@ public enum ExceptionMessage {
 
     // 서버 관련
     INTERNAL_SERVER(new InternalServerException("서버 에러입니다. 서버 관리자에게 문의주세요.", 500)),
+    SERVICE_UNAVAILABLE(new InternalServerException("접속자가 많습니다. 다시 시도해주세요.", 503)),
 
     // 회원 6xx
     NOT_FOUND_ACCOUNT(new NotFoundException("해당하는 유저를 찾을 수 없습니다.", 601)),

--- a/src/main/java/com/pet/common/util/OptimisticLockingHandlingUtils.java
+++ b/src/main/java/com/pet/common/util/OptimisticLockingHandlingUtils.java
@@ -1,6 +1,7 @@
 package com.pet.common.util;
 
 import com.pet.common.exception.ExceptionMessage;
+import java.util.Optional;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -13,30 +14,6 @@ public class OptimisticLockingHandlingUtils {
     }
 
     public static void handling(Runnable runnable, int handlingCount, String description) {
-        for (int i = 0; i < handlingCount; i++) {
-            try {
-                runnable.run();
-                break;
-            } catch (ObjectOptimisticLockingFailureException e) {
-                log.warn("#{}: locking failure occurred when try {}", handlingCount, description);
-            }
-        }
-    }
-
-    public static <T> T handling2(Supplier<T> supplier, T defaultValue, int handlingCount, String description) {
-        T result = defaultValue;
-        for (int i = 0; i < handlingCount; i++) {
-            try {
-                result = supplier.get();
-                break;
-            } catch (ObjectOptimisticLockingFailureException ex) {
-                log.warn("#{}: locking failure occurred when try {}", i, description);
-            }
-        }
-        return result;
-    }
-
-    public static void handling2(Runnable runnable, int handlingCount, String description) {
         boolean isFailure = true;
         for (int i = 0; i < handlingCount; i++) {
             try {
@@ -50,5 +27,16 @@ public class OptimisticLockingHandlingUtils {
         if (isFailure) {
             throw ExceptionMessage.SERVICE_UNAVAILABLE.getException();
         }
+    }
+
+    public static <T> Optional<T> handling(Supplier<T> supplier, int handlingCount, String description) {
+        for (int i = 0; i < handlingCount; i++) {
+            try {
+                return Optional.ofNullable(supplier.get());
+            } catch (ObjectOptimisticLockingFailureException ex) {
+                log.warn("#{}: locking failure occurred when try {}", i, description);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/pet/domains/comment/service/CommentService.java
+++ b/src/main/java/com/pet/domains/comment/service/CommentService.java
@@ -1,7 +1,6 @@
 package com.pet.domains.comment.service;
 
 import com.pet.common.exception.ExceptionMessage;
-import com.pet.common.util.OptimisticLockingHandlingUtils;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.comment.domain.Comment;
 import com.pet.domains.comment.dto.request.CommentCreateParam;
@@ -38,11 +37,6 @@ public class CommentService {
     @Transactional
     public CommentWriteResult createComment(Account account, CommentCreateParam commentCreateParam) {
         MissingPost missingPost = getMissingPostById(commentCreateParam.getPostId());
-        OptimisticLockingHandlingUtils.handling(
-            missingPost::increaseCommentCount,
-            5,
-            "실종 게시글 댓글 카운트 증가"
-        );
         return commentMapper.toCommentWriteResult(
             commentRepository.save(getNewComment(account, commentCreateParam, missingPost))
         );
@@ -59,11 +53,6 @@ public class CommentService {
     @Transactional
     public void deleteMyCommentById(Account account, Long commentId) {
         Comment foundComment = getMyComment(commentId, account);
-        OptimisticLockingHandlingUtils.handling(
-            foundComment.getMissingPost()::decreaseCommentCount,
-            5,
-            "실종 게시글 댓글 카운트 감소"
-        );
         commentRepository.delete(foundComment);
     }
 

--- a/src/main/java/com/pet/domains/post/controller/MissingPostController.java
+++ b/src/main/java/com/pet/domains/post/controller/MissingPostController.java
@@ -125,14 +125,12 @@ public class MissingPostController {
 
     private Optional<MissingPostReadResult> getMissingPostOneResult(Account account, Long postId) {
         if (Objects.nonNull(account)) {
-            System.out.println("1");
             return OptimisticLockingHandlingUtils.handling(
                 () -> missingPostService.getMissingPostOneWithAccount(account, postId),
                 10,
                 "실종/보호 게시물 단건 조회 with jwt"
             );
         }
-        System.out.println("2");
         return OptimisticLockingHandlingUtils.handling(
             () -> missingPostService.getMissingPostOne(postId),
             10,

--- a/src/main/java/com/pet/domains/post/domain/MissingPost.java
+++ b/src/main/java/com/pet/domains/post/domain/MissingPost.java
@@ -30,6 +30,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.Validate;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Formula;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -75,10 +76,10 @@ public class MissingPost extends DeletableEntity {
     @Column(name = "view_count", columnDefinition = "BIGINT default 0", nullable = false)
     private long viewCount;
 
-    @Column(name = "bookmark_count", columnDefinition = "BIGINT default 0", nullable = false)
+    @Formula("(select count(*) from missing_post_bookmark mpb where mpb.missing_post_id = id)")
     private long bookmarkCount;
 
-    @Column(name = "comment_count", columnDefinition = "BIGINT default 0", nullable = false)
+    @Formula("(select count(*) from comment c where c.missing_post_id = id)")
     private long commentCount;
 
     @Column(name = "thumbnail")
@@ -152,26 +153,6 @@ public class MissingPost extends DeletableEntity {
 
     public void increaseViewCount() {
         this.viewCount += 1;
-    }
-
-    public void increaseBookCount() {
-        this.bookmarkCount += 1;
-    }
-
-    public void decreaseBookCount() {
-        if (this.bookmarkCount > 0) {
-            this.bookmarkCount -= 1;
-        }
-    }
-
-    public void increaseCommentCount() {
-        this.commentCount += 1;
-    }
-
-    public void decreaseCommentCount() {
-        if (this.commentCount > 0) {
-            this.commentCount -= 1;
-        }
     }
 
 }

--- a/src/main/java/com/pet/domains/post/domain/ShelterPost.java
+++ b/src/main/java/com/pet/domains/post/domain/ShelterPost.java
@@ -16,12 +16,12 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import javax.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.Validate;
+import org.hibernate.annotations.Formula;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -98,7 +98,7 @@ public class ShelterPost extends BaseEntity {
     @Column(name = "notice_number", length = 30)
     private String noticeNumber;
 
-    @Column(name = "bookmark_count", columnDefinition = "BIGINT default 0")
+    @Formula("(select count(*) from shelter_post_bookmark spb where spb.shelter_post_id = id)")
     private long bookmarkCount;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -118,9 +118,6 @@ public class ShelterPost extends BaseEntity {
         nullable = false
     )
     private AnimalKind animalKind;
-
-    @Version
-    private long version;
 
     @Builder
     public ShelterPost(int age, String address, String shelterPlace, String shelterName, String shelterTelNumber,
@@ -156,16 +153,6 @@ public class ShelterPost extends BaseEntity {
         this.bookmarkCount = bookmarkCount;
         this.town = town;
         this.animalKind = animalKind;
-    }
-
-    public void increaseBookMarkCount() {
-        this.bookmarkCount += 1;
-    }
-
-    public void decreaseBookMarkCount() {
-        if (this.bookmarkCount > 0) {
-            this.bookmarkCount -= 1;
-        }
     }
 
 }

--- a/src/main/java/com/pet/domains/post/repository/MissingPostBookmarkRepository.java
+++ b/src/main/java/com/pet/domains/post/repository/MissingPostBookmarkRepository.java
@@ -1,12 +1,11 @@
 package com.pet.domains.post.repository;
 
 import com.pet.domains.account.domain.Account;
-import com.pet.domains.post.domain.MissingPost;
 import com.pet.domains.post.domain.MissingPostBookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissingPostBookmarkRepository extends JpaRepository<MissingPostBookmark, Long> {
 
-    Long deleteByAccountAndMissingPost(Account account, MissingPost missingPost);
+    Long deleteByAccountAndMissingPostId(Account account, Long missingPostId);
 
 }

--- a/src/main/java/com/pet/domains/post/service/MissingPostBookmarkService.java
+++ b/src/main/java/com/pet/domains/post/service/MissingPostBookmarkService.java
@@ -1,13 +1,11 @@
 package com.pet.domains.post.service;
 
 import com.pet.common.exception.ExceptionMessage;
-import com.pet.common.util.OptimisticLockingHandlingUtils;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.post.domain.MissingPost;
 import com.pet.domains.post.domain.MissingPostBookmark;
 import com.pet.domains.post.repository.MissingPostBookmarkRepository;
 import com.pet.domains.post.repository.MissingPostRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,33 +30,12 @@ public class MissingPostBookmarkService {
                 .missingPost(getMissingPost)
                 .build()
         );
-        OptimisticLockingHandlingUtils.handling(
-            getMissingPost::increaseBookCount,
-            5,
-            "실종/보호 게시글 북마크 증가"
-        );
     }
 
     @Transactional
     public void deleteMissingPostBookmark(Long postId, Account account) {
-        MissingPost getMissingPost = missingPostRepository.findById(postId)
-            .orElseThrow(ExceptionMessage.NOT_FOUND_MISSING_POST::getException);
+        missingPostBookmarkRepository.deleteByAccountAndMissingPostId(account, postId);
 
-        Long resultCount = missingPostBookmarkRepository.deleteByAccountAndMissingPost(account, getMissingPost);
-        if (Objects.nonNull(resultCount) && resultCount == 1L) {
-            MissingPost foundPost = missingPostRepository.findById(postId)
-                .orElseThrow(ExceptionMessage.NOT_FOUND_MISSING_POST::getException);
-            OptimisticLockingHandlingUtils.handling(
-                foundPost::decreaseBookCount,
-                5,
-                "실종/보호 게시글 북마크 감소"
-            );
-        }
-        OptimisticLockingHandlingUtils.handling(
-            getMissingPost::decreaseBookCount,
-            5,
-            "북마크 카운트 감소 연산"
-        );
     }
 
 }

--- a/src/main/java/com/pet/domains/post/service/ShelterPostBookmarkService.java
+++ b/src/main/java/com/pet/domains/post/service/ShelterPostBookmarkService.java
@@ -1,13 +1,11 @@
 package com.pet.domains.post.service;
 
 import com.pet.common.exception.ExceptionMessage;
-import com.pet.common.util.OptimisticLockingHandlingUtils;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.post.domain.ShelterPost;
 import com.pet.domains.post.domain.ShelterPostBookmark;
 import com.pet.domains.post.repository.ShelterPostBookmarkRepository;
 import com.pet.domains.post.repository.ShelterPostRepository;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,25 +29,11 @@ public class ShelterPostBookmarkService {
                 .account(account)
                 .build()
         );
-        OptimisticLockingHandlingUtils.handling(
-            foundPost::increaseBookMarkCount,
-            5,
-            "보호소 게시글 북마크 증가"
-        );
     }
 
     @Transactional
     public void deletePostBookmark(Long postId, Account account) {
-        Long result = shelterPostBookmarkRepository.deleteByShelterPostIdAndAccount(postId, account);
-        if (Objects.nonNull(result) && result.intValue() == 1L) {
-            ShelterPost foundPost = shelterPostRepository.findById(postId)
-                .orElseThrow(ExceptionMessage.NOT_FOUND_SHELTER_POST::getException);
-            OptimisticLockingHandlingUtils.handling(
-                foundPost::decreaseBookMarkCount,
-                5,
-                "보호소 게시글 북마크 감소"
-            );
-        }
+        shelterPostBookmarkRepository.deleteByShelterPostIdAndAccount(postId, account);
     }
 
 }

--- a/src/main/java/com/pet/domains/tag/domain/Tag.java
+++ b/src/main/java/com/pet/domains/tag/domain/Tag.java
@@ -7,12 +7,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import javax.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.ObjectUtils;
+import org.hibernate.annotations.Formula;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,29 +28,14 @@ public class Tag extends BaseEntity {
     @Column(name = "name", nullable = false, unique = true)
     private String name;
 
-    @Column(name = "count", columnDefinition = "BIGINT default 0", nullable = false)
+    @Formula("(select count(*) from post_tag pt where pt.tag_id = id)")
     private long count;
 
-    @Version
-    private long version;
-
     @Builder
-    public Tag(String name, long count) {
+    public Tag(String name) {
         ObjectUtils.requireNonEmpty(name, "name must not be null");
-        ObjectUtils.requireNonEmpty(count, "count must not be null");
 
         this.name = name;
-        this.count = count;
-    }
-
-    public void increaseCount() {
-        this.count += 1;
-    }
-
-    public void decreaseCount() {
-        if (this.count > 0) {
-            this.count -= 1;
-        }
     }
 
 }

--- a/src/main/java/com/pet/domains/tag/service/TagService.java
+++ b/src/main/java/com/pet/domains/tag/service/TagService.java
@@ -1,10 +1,7 @@
 package com.pet.domains.tag.service;
 
-import com.pet.common.util.OptimisticLockingHandlingUtils;
-import com.pet.domains.tag.domain.PostTag;
 import com.pet.domains.tag.domain.Tag;
 import com.pet.domains.tag.repository.TagRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,27 +16,11 @@ public class TagService {
     @Transactional
     public Tag getOrCreateByTagName(String tagName) {
         return tagRepository.findTagByName(tagName)
-            .map(tag -> {
-                OptimisticLockingHandlingUtils.handling(
-                    tag::increaseCount,
-                    5,
-                    "태그 카운트 증가 로직"
-                );
-                return tag;
-            })
             .orElseGet(() -> tagRepository.save(
                 Tag.builder()
                     .name(tagName)
-                    .count(1)
                     .build())
             );
-    }
-
-    @Transactional
-    public void decreaseTagCount(List<PostTag> postTags) {
-        postTags.stream()
-            .map(PostTag::getTag)
-            .forEach(Tag::decreaseCount);
     }
 
 }

--- a/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
+++ b/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
@@ -160,11 +160,12 @@ class MissingPostBookmarkRepositoryTest {
         missingPostBookmarkRepository.save(missingPostBookmark);
 
         //when
-        missingPostBookmarkRepository.deleteByAccountAndMissingPost(account, missingPost);
+        System.out.println("here");
+        missingPostBookmarkRepository.deleteByAccountAndMissingPostId(account, missingPost.getId());
 
         //then
         List<MissingPostBookmark> getMissingPostBookmarks = missingPostBookmarkRepository.findAll();
-        assertThat(getMissingPostBookmarks.size()).isEqualTo(0);
+        assertThat(getMissingPostBookmarks).isEmpty();
     }
 
 }

--- a/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
+++ b/src/test/java/com/pet/domains/post/repository/MissingPostBookmarkRepositoryTest.java
@@ -160,7 +160,6 @@ class MissingPostBookmarkRepositoryTest {
         missingPostBookmarkRepository.save(missingPostBookmark);
 
         //when
-        System.out.println("here");
         missingPostBookmarkRepository.deleteByAccountAndMissingPostId(account, missingPost.getId());
 
         //then

--- a/src/test/java/com/pet/domains/post/repository/MissingPostRepositoryTest.java
+++ b/src/test/java/com/pet/domains/post/repository/MissingPostRepositoryTest.java
@@ -153,7 +153,6 @@ class MissingPostRepositoryTest {
 
         tag = Tag.builder()
             .name("웰시코기")
-            .count(1)
             .build();
         tagRepository.save(tag);
 

--- a/src/test/java/com/pet/domains/post/repository/MissingPostRepositoryTest.java
+++ b/src/test/java/com/pet/domains/post/repository/MissingPostRepositoryTest.java
@@ -32,8 +32,6 @@ import com.pet.domains.tag.repository.PostTagRepository;
 import com.pet.domains.tag.repository.TagRepository;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.LongStream;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,9 +42,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import static org.assertj.core.api.Assertions.*;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @DataJpaTest(includeFilters = @Filter(
@@ -231,10 +226,6 @@ class MissingPostRepositoryTest {
         List<Comment> getComments = commentRepository.findAllByMissingPostId(missingPost.getId());
 
         List<PostTag> getPostTags = postTagRepository.getPostTagsByMissingPostId(missingPost.getId());
-
-        getPostTags.stream()
-            .map(PostTag::getTag)
-            .forEach(Tag::decreaseCount);
         Tag getTag = tagRepository.findById(tag.getId()).get();
 
         missingPostRepository.deleteById(missingPost.getId());

--- a/src/test/java/com/pet/domains/post/service/MissingPostBookmarkServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/MissingPostBookmarkServiceTest.java
@@ -59,10 +59,10 @@ class MissingPostBookmarkServiceTest {
     @DisplayName("실종/보호 게시물 북마크 삭제 테스트")
     void deleteMissingPostBookmarkTest() {
         //given
-        given(missingPostBookmarkRepository.deleteByAccountAndMissingPost(any(), any())).willReturn(null);
+        given(missingPostBookmarkRepository.deleteByAccountAndMissingPostId(any(), any())).willReturn(null);
 
         //when
-        missingPostBookmarkRepository.deleteByAccountAndMissingPost(
+        missingPostBookmarkRepository.deleteByAccountAndMissingPostId(
             Account.builder()
                 .nickname("nickname")
                 .password("123123123")
@@ -85,11 +85,11 @@ class MissingPostBookmarkServiceTest {
                 .account(mock(Account.class))
                 .town(mock(Town.class))
                 .animalKind(mock(AnimalKind.class))
-                .build()
+                .build().getId()
         );
 
         //then
-        verify(missingPostBookmarkRepository, times(1)).deleteByAccountAndMissingPost(any(), any());
+        verify(missingPostBookmarkRepository, times(1)).deleteByAccountAndMissingPostId(any(), any());
     }
 
 }

--- a/src/test/java/com/pet/domains/post/service/MissingPostServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/MissingPostServiceTest.java
@@ -10,24 +10,18 @@ import static org.mockito.Mockito.verify;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.animal.domain.Animal;
 import com.pet.domains.animal.domain.AnimalKind;
-import com.pet.domains.animal.service.AnimalKindService;
 import com.pet.domains.area.domain.City;
 import com.pet.domains.area.domain.Town;
-import com.pet.domains.area.repository.TownRepository;
 import com.pet.domains.auth.domain.Group;
 import com.pet.domains.image.domain.Image;
 import com.pet.domains.image.domain.PostImage;
-import com.pet.domains.image.repository.PostImageRepository;
-import com.pet.domains.image.service.ImageService;
 import com.pet.domains.post.domain.MissingPost;
 import com.pet.domains.post.domain.SexType;
 import com.pet.domains.post.domain.Status;
-import com.pet.domains.post.mapper.MissingPostMapper;
 import com.pet.domains.post.repository.MissingPostRepository;
 import com.pet.domains.post.repository.projection.MissingPostWithIsBookmark;
 import com.pet.domains.tag.domain.PostTag;
 import com.pet.domains.tag.domain.Tag;
-import com.pet.domains.tag.service.TagService;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,23 +43,6 @@ class MissingPostServiceTest {
     @Mock
     private MissingPostRepository missingPostRepository;
 
-    @Mock
-    private AnimalKindService animalKindService;
-
-    @Mock
-    private TownRepository townRepository;
-
-    @Mock
-    private PostImageRepository postImageRepository;
-
-    @Mock
-    private TagService tagService;
-
-    @Mock
-    private ImageService imageService;
-
-    @Mock
-    private MissingPostMapper missingPostMapper;
 
     private Group group;
 
@@ -113,7 +90,6 @@ class MissingPostServiceTest {
 
         tag = Tag.builder()
             .name("웰시코기")
-            .count(0)
             .build();
 
         animal = Animal.builder()

--- a/src/test/java/com/pet/domains/post/service/ShelterPostBookmarkServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/ShelterPostBookmarkServiceTest.java
@@ -74,7 +74,6 @@ class ShelterPostBookmarkServiceTest {
         // then
         ArgumentCaptor<ShelterPostBookmark> captor = ArgumentCaptor.forClass(ShelterPostBookmark.class);
         verify(shelterPostBookmarkRepository, times(1)).save(captor.capture());
-        verify(spyShelterPost).increaseBookMarkCount();
         assertThat(spyShelterPost.getBookmarkCount()).isEqualTo(11);
     }
 
@@ -124,7 +123,6 @@ class ShelterPostBookmarkServiceTest {
 
         // then
         verify(shelterPostBookmarkRepository, times(1)).deleteByShelterPostIdAndAccount(anyLong(), any(Account.class));
-        verify(spyShelterPost).decreaseBookMarkCount();
         assertThat(spyShelterPost.getBookmarkCount()).isEqualTo(9);
 
     }

--- a/src/test/java/com/pet/domains/post/service/ShelterPostBookmarkServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/ShelterPostBookmarkServiceTest.java
@@ -1,6 +1,5 @@
 package com.pet.domains.post.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -74,7 +73,6 @@ class ShelterPostBookmarkServiceTest {
         // then
         ArgumentCaptor<ShelterPostBookmark> captor = ArgumentCaptor.forClass(ShelterPostBookmark.class);
         verify(shelterPostBookmarkRepository, times(1)).save(captor.capture());
-        assertThat(spyShelterPost.getBookmarkCount()).isEqualTo(11);
     }
 
     @Test
@@ -123,8 +121,6 @@ class ShelterPostBookmarkServiceTest {
 
         // then
         verify(shelterPostBookmarkRepository, times(1)).deleteByShelterPostIdAndAccount(anyLong(), any(Account.class));
-        assertThat(spyShelterPost.getBookmarkCount()).isEqualTo(9);
-
     }
 
 }

--- a/src/test/java/com/pet/domains/post/service/ShelterPostBookmarkServiceTest.java
+++ b/src/test/java/com/pet/domains/post/service/ShelterPostBookmarkServiceTest.java
@@ -112,7 +112,6 @@ class ShelterPostBookmarkServiceTest {
                     .build())
                 .bookmarkCount(10)
                 .build());
-        given(shelterPostRepository.findById(anyLong())).willReturn(Optional.of(spyShelterPost));
         given(shelterPostBookmarkRepository.deleteByShelterPostIdAndAccount(anyLong(), any(Account.class)))
             .willReturn(1L);
 

--- a/src/test/java/com/pet/domains/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/com/pet/domains/tag/repository/TagRepositoryTest.java
@@ -33,7 +33,6 @@ class TagRepositoryTest {
         // given
         Tag tag = Tag.builder()
             .name("웰시코기")
-            .count(0)
             .build();
         entityManager.persist(tag);
 


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #287 

## 내용
- 설명 : 고정적이고 정확해야하는 카운트 값들은 필드에서 제외하고 formula를 사용하도록 했습니다

사용 장점
- 서브쿼리 사용
- 비즈니스 로직 굉장히 간단해집니다. -> 삭제 & 생성시 카운트 관련 필드 로직과 값의 정합성 고려 안해도됨
-  insert 트랜잭션은 낙관적 락으로 막을 수없음 바로 데드락, lost update 막기 위한 용도로 사용하는 전용인듯합니다
    - 즉 댓글, 북마크 생성 트랜잭션에 카운트 증가로직이 있으면 별도의 서비스로 빼지 않는 이상 처리가 굉장히 힘듦
    - 서비스 순환 참조 가능성, 컨트롤러에서 로직? 처리 
- update 로직에는 낙관적 락 사용 -> 조회수 잘 올라가는 것 같습니다 물론 예외처리 비용이 있겟지만

단점 & 특징?
- lazy 처리하지 않는이상 일단 eager,
- 네이티브 쿼리 사용

## 추가 및 변경 로직
- 조회수를 제외한 모든 Increase 로직 & 필드로 관리 x
- 낙관적 락 핸들러 추가 -> 503

## 참고 및 기타
동시 call 간단 테스트
![image](https://user-images.githubusercontent.com/56071126/146657685-806b53f8-59ab-4eb2-a894-276d92d8a00d.png)
![image](https://user-images.githubusercontent.com/56071126/146657735-260d97fe-ca05-433f-947a-7eedb0b88f93.png)
