### PR TITLE
[CP-388] refactor: account service 분리

### DIFF
--- a/src/main/java/com/pet/common/config/SecurityConfig.java
+++ b/src/main/java/com/pet/common/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import com.pet.common.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.pet.common.oauth2.OAuth2AuthenticationSuccessHandler;
 import com.pet.common.property.JwtProperty;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import java.io.IOException;
 import java.util.Objects;
 import javax.servlet.http.HttpServletResponse;
@@ -60,8 +61,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
-    public JwtAuthenticationProvider jwtAuthenticationProvider(AccountService accountService, Jwt jwt) {
-        return new JwtAuthenticationProvider(jwt, accountService);
+    public JwtAuthenticationProvider jwtAuthenticationProvider(LoginService loginService, Jwt jwt) {
+        return new JwtAuthenticationProvider(jwt, loginService);
     }
 
     @Bean
@@ -88,9 +89,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler(
-        Jwt jwt, AccountService accountService
+        Jwt jwt, LoginService loginService
     ) {
-        return new OAuth2AuthenticationSuccessHandler(jwt, accountService);
+        return new OAuth2AuthenticationSuccessHandler(jwt, loginService);
     }
 
     @Bean

--- a/src/main/java/com/pet/common/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/pet/common/jwt/JwtAuthenticationProvider.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.ClassUtils.*;
 import com.pet.common.exception.ExceptionMessage;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -15,7 +16,8 @@ import org.springframework.security.core.GrantedAuthority;
 public class JwtAuthenticationProvider implements AuthenticationProvider {
 
     private final Jwt jwt;
-    private final AccountService accountService;
+
+    private final LoginService loginService;
 
     @Override
     public boolean supports(Class<?> authentication) {
@@ -35,7 +37,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     }
 
     private Account login(String principal, String credentials) {
-        return accountService.login(principal, credentials);
+        return loginService.login(principal, credentials);
     }
 
     private JwtAuthenticationToken generateJwtAuthenticationToken(Account account) {

--- a/src/main/java/com/pet/common/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/pet/common/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -11,7 +11,6 @@ public class HttpCookieOAuth2AuthorizationRequestRepository
     implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
     private static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
-
     public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
 
     private static final int COOKIE_EXPIRE_SECONDS = 180;

--- a/src/main/java/com/pet/common/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/pet/common/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -4,6 +4,7 @@ import com.pet.common.config.CookieUtil;
 import com.pet.common.jwt.Jwt;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import java.io.IOException;
 import java.util.Optional;
 import javax.servlet.ServletException;
@@ -22,7 +23,7 @@ public class OAuth2AuthenticationSuccessHandler extends SavedRequestAwareAuthent
 
     private final Jwt jwt;
 
-    private final AccountService accountService;
+    private final LoginService loginService;
 
     @Override
     public void onAuthenticationSuccess(
@@ -37,14 +38,6 @@ public class OAuth2AuthenticationSuccessHandler extends SavedRequestAwareAuthent
                 .fromUriString("https://comepet.netlify.app/oauth/redirect?").queryParam("token", token)
                 .build().toUriString();
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
-            // String loginSuccessJson =  "{\"username\": \"" + account.getId() + "\", \"token\":\""
-            //     + token + "\"}";
-            // setResponse(response, loginSuccessJson);
-
-            // response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            // response.setContentLength(loginSuccessJson.getBytes(StandardCharsets.UTF_8).length);
-            // response.getWriter().write(loginSuccessJson);
-            // response.sendRedirect("https://comepet.netlify.app/oauth/redirect?token=" + token);
             return;
         }
         super.onAuthenticationSuccess(request, response, authentication);
@@ -61,23 +54,11 @@ public class OAuth2AuthenticationSuccessHandler extends SavedRequestAwareAuthent
     private Account processUserOAuth2UserJoin(OAuth2AuthenticationToken authentication) {
         OAuth2User oAuth2User = authentication.getPrincipal();
         String registrationId = authentication.getAuthorizedClientRegistrationId();
-        return accountService.joinOath2User(oAuth2User, registrationId);
+        return loginService.joinOath2User(oAuth2User, registrationId);
     }
 
     private String generateToken(Account account) {
         return jwt.sign(Jwt.Claims.from(account.getId(), new String[] {"ROLE_USER"}));
     }
-
-    // protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
-    //     super.clearAuthenticationAttributes(request);
-    //     authorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
-    // }
-
-    // private void setResponse(HttpServletResponse response, String loginSuccessJson) throws IOException {
-    //     response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-    //     response.setContentLength(loginSuccessJson.getBytes(StandardCharsets.UTF_8).length);
-    //     response.getWriter().write(loginSuccessJson);
-    //     response.sendRedirect("http://comepet.netlify.app/oauth/" + );
-    // }
 
 }

--- a/src/main/java/com/pet/common/util/Assertions.java
+++ b/src/main/java/com/pet/common/util/Assertions.java
@@ -1,0 +1,17 @@
+package com.pet.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Slf4j
+public class Assertions {
+
+    public static void assertThrow(boolean condition, RuntimeException exception) {
+        if (condition) {
+            log.debug(exception.getMessage());
+            throw exception;
+        }
+    }
+}

--- a/src/main/java/com/pet/common/util/PasswordUtil.java
+++ b/src/main/java/com/pet/common/util/PasswordUtil.java
@@ -1,0 +1,13 @@
+package com.pet.common.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PasswordUtil {
+
+    public static boolean match(String password) {
+        return password.matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$");
+    }
+
+}

--- a/src/main/java/com/pet/common/util/Random.java
+++ b/src/main/java/com/pet/common/util/Random.java
@@ -1,0 +1,13 @@
+package com.pet.common.util;
+
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Random {
+
+    public static String randomNewPassword() {
+        return UUID.randomUUID().toString().replaceAll("-", "").substring(0, 10);
+    }
+}

--- a/src/main/java/com/pet/domains/account/controller/AccountController.java
+++ b/src/main/java/com/pet/domains/account/controller/AccountController.java
@@ -17,6 +17,7 @@ import com.pet.domains.account.dto.response.AccountLoginResult;
 import com.pet.domains.account.dto.response.AccountMissingPostPageResults;
 import com.pet.domains.account.dto.response.AccountReadResult;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import com.pet.domains.auth.service.AuthenticationService;
 import com.pet.domains.post.service.MissingPostService;
 import com.pet.domains.post.service.ShelterPostService;
@@ -55,30 +56,32 @@ public class AccountController {
 
     private final ShelterPostService shelterPostService;
 
+    private final LoginService loginService;
+
     @PostMapping(path = "/send-email", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void sendEmail(@RequestBody @Valid AccountEmailParam accountEmailParam) {
-        accountService.sendEmail(accountEmailParam.getEmail());
+        loginService.sendEmail(accountEmailParam.getEmail());
     }
 
     @PatchMapping(path = "/send-password", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void sendPassword(@Valid @RequestBody AccountEmailParam param) {
-        accountService.sendPassword(param.getEmail());
+        loginService.sendPassword(param.getEmail());
     }
 
     @PostMapping(path = "/verify-email", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<Map<String, Long>> verifyEmail(@RequestBody @Valid AccountEmailCheck accountEmailCheck) {
         return ApiResponse.ok(
-            Map.of("id", accountService.verifyEmail(accountEmailCheck.getEmail(), accountEmailCheck.getKey())));
+            Map.of("id", loginService.verifyEmail(accountEmailCheck.getEmail(), accountEmailCheck.getKey())));
     }
 
     @PostMapping(path = "/sign-up",
         consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<AccountCreateResult> signUp(@RequestBody @Valid AccountSignUpParam accountSignUpParam) {
-        Long id = accountService.signUp(accountSignUpParam);
+        Long id = loginService.signUp(accountSignUpParam);
         return ApiResponse.ok(AccountCreateResult.of(id, authenticationService.authenticate(
             accountSignUpParam.getEmail(), accountSignUpParam.getPassword()).getToken()));
     }

--- a/src/main/java/com/pet/domains/account/service/AccountService.java
+++ b/src/main/java/com/pet/domains/account/service/AccountService.java
@@ -1,40 +1,27 @@
 package com.pet.domains.account.service;
 
-import com.pet.common.exception.ExceptionMessage;
+import static com.pet.common.exception.ExceptionMessage.*;
+import static com.pet.common.util.Assertions.*;
+import com.pet.common.util.PasswordUtil;
 import com.pet.domains.account.domain.Account;
-import com.pet.domains.account.domain.AccountGroup;
-import com.pet.domains.account.domain.Provider;
-import com.pet.domains.account.domain.SignEmail;
 import com.pet.domains.account.dto.request.AccountAreaUpdateParam;
-import com.pet.domains.account.dto.request.AccountSignUpParam;
 import com.pet.domains.account.dto.request.AccountUpdateParam;
 import com.pet.domains.account.dto.response.AccountAreaReadResults;
 import com.pet.domains.account.dto.response.AccountMissingPostPageResults;
 import com.pet.domains.account.dto.response.AccountReadResult;
 import com.pet.domains.account.mapper.AccountMapper;
 import com.pet.domains.account.repository.AccountRepository;
-import com.pet.domains.account.repository.SignEmailRepository;
 import com.pet.domains.area.domain.InterestArea;
 import com.pet.domains.area.domain.Town;
 import com.pet.domains.area.mapper.InterestAreaMapper;
 import com.pet.domains.area.repository.InterestAreaRepository;
 import com.pet.domains.area.repository.TownRepository;
-import com.pet.domains.auth.domain.Group;
-import com.pet.domains.auth.oauth2.Oauth2User;
-import com.pet.domains.auth.oauth2.ProviderType;
-import com.pet.domains.auth.repository.GroupRepository;
 import com.pet.domains.image.domain.Image;
 import com.pet.domains.image.service.ImageService;
 import com.pet.domains.post.domain.MissingPost;
 import com.pet.domains.post.repository.MissingPostRepository;
-import com.pet.infra.EmailMessage;
-import com.pet.infra.MailSender;
-import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +29,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -57,12 +43,6 @@ public class AccountService {
 
     private final PasswordEncoder passwordEncoder;
 
-    private final MailSender mailSender;
-
-    private final SignEmailRepository signEmailRepository;
-
-    private final GroupRepository groupRepository;
-
     private final InterestAreaRepository interestAreaRepository;
 
     private final TownRepository townRepository;
@@ -76,154 +56,55 @@ public class AccountService {
     private final AccountMapper accountMapper;
 
     @Transactional
-    public void sendEmail(String email) {
-        if (accountRepository.existsByEmail(email)) {
-            throw ExceptionMessage.DUPLICATION_EMAIL.getException();
-        }
-        String verifyKey = UUID.randomUUID().toString();
-        mailSender.send(EmailMessage.crateVerifyEmailMessage(email, verifyKey));
-        signEmailRepository.save(new SignEmail(email, verifyKey));
-    }
-
-    @Transactional
-    public void sendPassword(String email) {
-        Account account =
-            accountRepository.findByEmail(email).orElseThrow(ExceptionMessage.NOT_FOUND_ACCOUNT::getException);
-        String temporaryPassword = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 10);
-        account.updatePassword(passwordEncoder.encode(temporaryPassword));
-        mailSender.send(EmailMessage.crateNewPasswordEmailMessage(account.getEmail(), temporaryPassword));
-    }
-
-    @Transactional
-    public Long verifyEmail(String email, String key) {
-        SignEmail signEmail = signEmailRepository.findByEmailAndVerifyKey(email, key)
-            .filter(findSignEmail -> findSignEmail.isVerifyTime(LocalDateTime.now()))
-            .orElseThrow(ExceptionMessage.INVALID_MAIL_KEY::getException);
-        signEmail.successVerified();
-        return signEmail.getId();
-    }
-
-    public Account login(String email, String password) {
-        Account account = accountRepository.findByEmail(email)
-            .orElseThrow(ExceptionMessage.NOT_FOUND_ACCOUNT::getException);
-        if (!account.isMatchPassword(passwordEncoder, password)) {
-            throw ExceptionMessage.INVALID_LOGIN.getException();
-        }
-        return account;
-    }
-
-    public Account checkLoginAccountById(Long accountId) {
-        return accountRepository.findByIdAndImage(accountId).orElseThrow(
-            ExceptionMessage.NOT_FOUND_ACCOUNT::getException
-        );
-    }
-
-    @Transactional
-    public Long signUp(AccountSignUpParam param) {
-        compareWithPassword(param);
-        checkSignEmail(param);
-        return accountRepository.save(Account.builder()
-            .email(param.getEmail())
-            .password(passwordEncoder.encode(param.getPassword()))
-            .nickname(param.getNickname())
-            .provider(Provider.LOCAL)
-            .group(groupRepository.findByName(AccountGroup.USER_GROUP.name())
-                .orElseThrow(ExceptionMessage.NOT_FOUND_GROUP::getException))
-            .build()).getId();
-    }
-
-    private void checkSignEmail(AccountSignUpParam param) {
-        signEmailRepository.findById(param.getVerifiedId())
-            .orElseThrow(ExceptionMessage.INVALID_SIGN_UP::getException)
-            .isVerifyEmail(param.getEmail());
-    }
-
-    private void compareWithPassword(AccountSignUpParam param) {
-        if (!StringUtils.equals(param.getPassword(), param.getPasswordCheck())) {
-            throw ExceptionMessage.INVALID_SIGN_UP.getException();
-        }
-    }
-
-    @Transactional
-    public Account joinOath2User(OAuth2User oAuth2User, String provider) {
-        Map<String, Object> attributes = oAuth2User.getAttributes();
-        Oauth2User oauth2User = ProviderType.findProvider(provider);
-        if (provider.equals(ProviderType.NAVER.getType())) {
-            attributes = (Map<String, Object>)attributes.get("response");
-        }
-        if (provider.equals(ProviderType.KAKAO.getType())) {
-            attributes = (Map<String, Object>)attributes.get("properties");
-        }
-        String email = oauth2User.getEmail(attributes);
-        return findByEmail(provider, attributes, oauth2User, email);
-    }
-
-    private Account findByEmail(String provider, Map<String, Object> attributes, Oauth2User oauth2User, String email) {
-        return accountRepository.findByEmail(email)
-            .orElseGet(() -> {
-                String nickname = oauth2User.getNickname(attributes);
-                String profileImage = oauth2User.getProfileImage(attributes);
-                Group group = groupRepository.findByName(AccountGroup.USER_GROUP.name())
-                    .orElseThrow(ExceptionMessage.NOT_FOUND_GROUP::getException);
-                return accountRepository.save(Account.builder().nickname(nickname).email(email)
-                    .provider(Provider.findByType(provider))
-                    .profileImage(new Image(profileImage)).group(group).build());
-            });
-    }
-
-    @Transactional
     public void updateArea(Account account, AccountAreaUpdateParam accountAreaUpdateParam) {
         interestAreaRepository.deleteAllByAccountId(account.getId());
 
         List<AccountAreaUpdateParam.Area> areas = accountAreaUpdateParam.getAreas();
-        if (areas.isEmpty()) {
-            log.debug("관심 지역을 0개 입력했습니다.");
-            throw ExceptionMessage.INVALID_INTEREST_AREA.getException();
-        }
+        assertThrow(areas.isEmpty(), INVALID_INTEREST_AREA.getException());
+        assertThrow(areas.size() > 2, INVALID_INTEREST_AREA.getException());
 
-        if (areas.size() > 2) {
-            log.debug("관심 지역이 2개를 넘었습니다.");
-            throw ExceptionMessage.INVALID_INTEREST_AREA.getException();
-        }
+        checkInterestAreaIsOne(account, accountAreaUpdateParam, areas);
+        checkInterestAreaIsTwo(account, areas);
+        account.updateNotification(accountAreaUpdateParam.isNotification());
+        accountRepository.save(account);
+    }
 
-        // 관심 지역이 1개인 경우 디폴트 지역으로 저장
+    private void checkInterestAreaIsTwo(Account account, List<AccountAreaUpdateParam.Area> areas) {
+        if (areas.size() == 2) {
+            validateDefaultAreaCount(areas);
+            validateTownIdCount(areas);
+            interestAreaRepository.saveAll(
+                areas.stream()
+                    .map(area -> interestAreaMapper.toEntity(account, area, findTownByArea(area)))
+                    .collect(Collectors.toList()));
+        }
+    }
+
+    private Town findTownByArea(AccountAreaUpdateParam.Area area) {
+        return townRepository.findById(area.getTownId())
+            .orElseThrow(NOT_FOUND_TOWN::getException);
+    }
+
+    private void checkInterestAreaIsOne(
+        Account account, AccountAreaUpdateParam accountAreaUpdateParam, List<AccountAreaUpdateParam.Area> areas
+    ) {
         if (areas.size() == 1) {
             AccountAreaUpdateParam.Area defaultArea = accountAreaUpdateParam.getAreas().get(0);
             InterestArea interestArea = interestAreaMapper.toEntity(account, defaultArea, findTownByArea(defaultArea));
             interestArea.checkSelect();
             interestAreaRepository.save(interestArea);
         }
-
-        if (areas.size() == 2) {
-            long defaultAreaCount = areas.stream().filter(AccountAreaUpdateParam.Area::isDefaultArea).count();
-            if (defaultAreaCount == 2) {
-                log.debug("디폴트 지역이 2개입니다.");
-                throw ExceptionMessage.INVALID_INTEREST_AREA.getException();
-            }
-            if (defaultAreaCount == 0) {
-                log.debug("디폴트 지역이 0개입니다.");
-                throw ExceptionMessage.INVALID_INTEREST_AREA.getException();
-            }
-
-            long townIdCount = areas.stream().map(AccountAreaUpdateParam.Area::getTownId).distinct().count();
-            if (townIdCount == 1) {
-                log.debug("타운 아이디가 같습니다.");
-                throw ExceptionMessage.INVALID_INTEREST_AREA.getException();
-            }
-
-            interestAreaRepository.saveAll(
-                areas.stream()
-                    .map(area -> interestAreaMapper.toEntity(account, area, findTownByArea(area)))
-                    .collect(Collectors.toList()));
-        }
-
-        account.updateNotification(accountAreaUpdateParam.isNotification());
-        accountRepository.save(account);
     }
 
-    private Town findTownByArea(AccountAreaUpdateParam.Area area) {
-        return townRepository.findById(area.getTownId())
-            .orElseThrow(ExceptionMessage.NOT_FOUND_TOWN::getException);
+    private void validateDefaultAreaCount(List<AccountAreaUpdateParam.Area> areas) {
+        long defaultAreaCount = areas.stream().filter(AccountAreaUpdateParam.Area::isDefaultArea).count();
+        assertThrow(defaultAreaCount == 2, INVALID_INTEREST_AREA.getException());
+        assertThrow(defaultAreaCount == 0, INVALID_INTEREST_AREA.getException());
+    }
+
+    private void validateTownIdCount(List<AccountAreaUpdateParam.Area> areas) {
+        long townIdCount = areas.stream().map(AccountAreaUpdateParam.Area::getTownId).distinct().count();
+        assertThrow(townIdCount == 1, INVALID_INTEREST_AREA.getException());
     }
 
     @Transactional
@@ -252,30 +133,20 @@ public class AccountService {
     }
 
     private void validatePassword(String password, String passwordCheck) {
-        if (!StringUtils.equals(password, passwordCheck)) {
-            log.debug("새로운 비밀번호의 입력값이 다릅니다.");
-            throw ExceptionMessage.INVALID_PASSWORD.getException();
-        }
-
-        if (StringUtils.isNotBlank(password)) {
-            if (!password
-                .matches("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$")) {
-                throw ExceptionMessage.INVALID_PASSWORD_REGEX.getException();
-            }
-        }
+        assertThrow(!StringUtils.equals(password, passwordCheck), INVALID_PASSWORD.getException());
+        assertThrow(StringUtils.isNotBlank(password) && !PasswordUtil.match(password),
+            INVALID_PASSWORD_REGEX.getException());
     }
 
     public AccountAreaReadResults getInterestArea(Account account) {
-        List<InterestArea> interestAreas = interestAreaRepository.findByAccountId(account.getId());
-        return AccountAreaReadResults.of(interestAreas.stream()
+        return AccountAreaReadResults.of(interestAreaRepository.findByAccountId(account.getId()).stream()
             .map(interestArea -> interestAreaMapper.toAreaResult(interestArea, account.isCheckedArea()))
             .collect(Collectors.toList()), account.isNotification());
     }
 
     public AccountReadResult getAccount(Account account) {
-        return accountMapper.toReadResult(
-            accountRepository.findByIdAndImage(account.getId())
-                .orElseThrow(ExceptionMessage.NOT_FOUND_ACCOUNT::getException));
+        return accountMapper.toReadResult(accountRepository.findByIdAndImage(account.getId())
+                .orElseThrow(NOT_FOUND_ACCOUNT::getException));
     }
 
     @Transactional
@@ -284,12 +155,11 @@ public class AccountService {
         InterestArea deletedArea = interestAreas.stream()
             .filter(interestArea -> interestArea.getId().equals(areaId))
             .findAny()
-            .orElseThrow(ExceptionMessage.NOT_FOUND_INTEREST_AREA::getException);
+            .orElseThrow(NOT_FOUND_INTEREST_AREA::getException);
         interestAreas.remove(deletedArea);
 
         interestAreaRepository.delete(deletedArea);
 
-        // 관심 지역을 하나 삭제하고 하나가 더 남아있는 경우 selected == false -> true
         if (interestAreas.size() == 1) {
             InterestArea interestArea = interestAreas.get(0);
             interestArea.checkSelect();

--- a/src/main/java/com/pet/domains/account/service/LoginService.java
+++ b/src/main/java/com/pet/domains/account/service/LoginService.java
@@ -1,0 +1,127 @@
+package com.pet.domains.account.service;
+
+import com.pet.common.util.Random;
+import com.pet.domains.account.domain.Account;
+import com.pet.domains.account.domain.AccountGroup;
+import com.pet.domains.account.domain.Provider;
+import com.pet.domains.account.domain.SignEmail;
+import com.pet.domains.account.dto.request.AccountSignUpParam;
+import com.pet.domains.account.repository.AccountRepository;
+import com.pet.domains.account.repository.SignEmailRepository;
+import com.pet.domains.auth.domain.Group;
+import com.pet.domains.auth.oauth2.Oauth2User;
+import com.pet.domains.auth.oauth2.ProviderType;
+import com.pet.domains.auth.repository.GroupRepository;
+import com.pet.domains.image.domain.Image;
+import com.pet.infra.EmailMessage;
+import com.pet.infra.MailSender;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import static com.pet.common.exception.ExceptionMessage.*;
+import static com.pet.common.util.Assertions.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final AccountRepository accountRepository;
+
+    private final MailSender mailSender;
+
+    private final SignEmailRepository signEmailRepository;
+
+    private final GroupRepository groupRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void sendEmail(String email) {
+        assertThrow(accountRepository.existsByEmail(email), DUPLICATION_EMAIL.getException());
+        String verifyKey = UUID.randomUUID().toString();
+        mailSender.send(EmailMessage.crateVerifyEmailMessage(email, verifyKey));
+        signEmailRepository.save(new SignEmail(email, verifyKey));
+    }
+
+    @Transactional
+    public void sendPassword(String email) {
+        Account account = accountRepository.findByEmail(email).orElseThrow(NOT_FOUND_ACCOUNT::getException);
+        String temporaryPassword = Random.randomNewPassword();
+        account.updatePassword(passwordEncoder.encode(temporaryPassword));
+        mailSender.send(EmailMessage.crateNewPasswordEmailMessage(account.getEmail(), temporaryPassword));
+    }
+
+    @Transactional
+    public Long verifyEmail(String email, String key) {
+        SignEmail signEmail = signEmailRepository.findByEmailAndVerifyKey(email, key)
+            .filter(findSignEmail -> findSignEmail.isVerifyTime(LocalDateTime.now()))
+            .orElseThrow(INVALID_MAIL_KEY::getException);
+        signEmail.successVerified();
+        return signEmail.getId();
+    }
+
+    public Account login(String email, String password) {
+        Account account = accountRepository.findByEmail(email).orElseThrow(NOT_FOUND_ACCOUNT::getException);
+        assertThrow(!account.isMatchPassword(passwordEncoder, password), INVALID_LOGIN.getException());
+        return account;
+    }
+
+    public Account checkLoginAccountById(Long accountId) {
+        return accountRepository.findByIdAndImage(accountId).orElseThrow(NOT_FOUND_ACCOUNT::getException);
+    }
+
+    @Transactional
+    public Long signUp(AccountSignUpParam param) {
+        compareWithPassword(param);
+        checkSignEmail(param);
+        return accountRepository.save(Account.builder()
+            .email(param.getEmail())
+            .password(passwordEncoder.encode(param.getPassword()))
+            .nickname(param.getNickname())
+            .provider(Provider.LOCAL)
+            .group(groupRepository.findByName(AccountGroup.USER_GROUP.name())
+                .orElseThrow(NOT_FOUND_GROUP::getException))
+            .build()).getId();
+    }
+
+    private void checkSignEmail(AccountSignUpParam param) {
+        signEmailRepository.findById(param.getVerifiedId())
+            .orElseThrow(INVALID_SIGN_UP::getException)
+            .isVerifyEmail(param.getEmail());
+    }
+
+    private void compareWithPassword(AccountSignUpParam param) {
+        assertThrow(!StringUtils.equals(param.getPassword(), param.getPasswordCheck()), INVALID_SIGN_UP.getException());
+    }
+
+    @Transactional
+    public Account joinOath2User(OAuth2User oAuth2User, String provider) {
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Oauth2User oauth2User = ProviderType.findProvider(provider);
+        String email = oauth2User.getEmail(attributes);
+        return findByOauthAccount(provider, attributes, oauth2User, email);
+    }
+
+    private Account findByOauthAccount(
+        String provider, Map<String, Object> attributes, Oauth2User oauth2User, String email
+    ) {
+        return accountRepository.findByEmail(email)
+            .orElseGet(() -> {
+                String nickname = oauth2User.getNickname(attributes);
+                String profileImage = oauth2User.getProfileImage(attributes);
+                Group group = groupRepository.findByName(AccountGroup.USER_GROUP.name())
+                    .orElseThrow(NOT_FOUND_GROUP::getException);
+                return accountRepository.save(Account.builder().nickname(nickname).email(email)
+                    .provider(Provider.findByType(provider))
+                    .profileImage(new Image(profileImage)).group(group).build());
+            });
+    }
+
+}

--- a/src/main/java/com/pet/domains/auth/HandlerMethodResolverArgumentConfig.java
+++ b/src/main/java/com/pet/domains/auth/HandlerMethodResolverArgumentConfig.java
@@ -1,6 +1,6 @@
 package com.pet.domains.auth;
 
-import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import com.pet.domains.auth.controller.argumentresolver.JwtAuthenticationArgumentResolver;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class HandlerMethodResolverArgumentConfig implements WebMvcConfigurer {
 
-    private final AccountService accountService;
+    private final LoginService loginService;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
@@ -22,7 +22,7 @@ public class HandlerMethodResolverArgumentConfig implements WebMvcConfigurer {
 
     @Bean
     public JwtAuthenticationArgumentResolver jwtAuthenticationArgumentResolver() {
-        return new JwtAuthenticationArgumentResolver(accountService);
+        return new JwtAuthenticationArgumentResolver(loginService);
     }
 
 }

--- a/src/main/java/com/pet/domains/auth/controller/argumentresolver/JwtAuthenticationArgumentResolver.java
+++ b/src/main/java/com/pet/domains/auth/controller/argumentresolver/JwtAuthenticationArgumentResolver.java
@@ -4,6 +4,7 @@ import com.pet.common.exception.ExceptionMessage;
 import com.pet.common.jwt.JwtAuthentication;
 import com.pet.domains.account.domain.LoginAccount;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -18,7 +19,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 public class JwtAuthenticationArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final AccountService accountService;
+    private final LoginService loginService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -37,7 +38,7 @@ public class JwtAuthenticationArgumentResolver implements HandlerMethodArgumentR
         if (isAnonymousAuthentication(authentication)) {
             return null;
         }
-        return accountService.checkLoginAccountById(getJwtAuthentication(authentication).getAccountId());
+        return loginService.checkLoginAccountById(getJwtAuthentication(authentication).getAccountId());
     }
 
     private JwtAuthentication getJwtAuthentication(Authentication authentication) {

--- a/src/main/java/com/pet/domains/auth/oauth2/KakaoUser.java
+++ b/src/main/java/com/pet/domains/auth/oauth2/KakaoUser.java
@@ -1,0 +1,39 @@
+package com.pet.domains.auth.oauth2;
+
+import java.util.Map;
+
+public class KakaoUser implements Oauth2User {
+
+    private static final String KAKAO_OAUTH = "properties";
+
+    private final String nickname;
+
+    private final String email;
+
+    private final String profileImage;
+
+    public KakaoUser(String nickname, String email, String profileImage) {
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImage = profileImage;
+    }
+
+    @Override
+    public String getNickname(Map<String, Object> attributes) {
+        return (String)getKakaoAttributes(attributes).get(nickname);
+    }
+
+    @Override
+    public String getEmail(Map<String, Object> attributes) {
+        return (String)getKakaoAttributes(attributes).get(email);
+    }
+
+    @Override
+    public String getProfileImage(Map<String, Object> attributes) {
+        return (String)getKakaoAttributes(attributes).get(profileImage);
+    }
+
+    private Map<String, Object> getKakaoAttributes(Map<String, Object> attributes) {
+        return (Map<String, Object>)attributes.get(KAKAO_OAUTH);
+    }
+}

--- a/src/main/java/com/pet/domains/auth/oauth2/NaverUser.java
+++ b/src/main/java/com/pet/domains/auth/oauth2/NaverUser.java
@@ -1,0 +1,39 @@
+package com.pet.domains.auth.oauth2;
+
+import java.util.Map;
+
+public class NaverUser implements Oauth2User {
+
+    private static final String NAVER_OAUTH = "response";
+
+    private final String nickname;
+
+    private final String email;
+
+    private final String profileImage;
+
+    public NaverUser(String nickname, String email, String profileImage) {
+        this.nickname = nickname;
+        this.email = email;
+        this.profileImage = profileImage;
+    }
+
+    @Override
+    public String getNickname(Map<String, Object> attributes) {
+        return (String)getNaverAttributes(attributes).get(nickname);
+    }
+
+    @Override
+    public String getEmail(Map<String, Object> attributes) {
+        return (String)getNaverAttributes(attributes).get(email);
+    }
+
+    @Override
+    public String getProfileImage(Map<String, Object> attributes) {
+        return (String)getNaverAttributes(attributes).get(profileImage);
+    }
+
+    private Map<String, Object> getNaverAttributes(Map<String, Object> attributes) {
+        return (Map<String, Object>)attributes.get(NAVER_OAUTH);
+    }
+}

--- a/src/main/java/com/pet/domains/auth/oauth2/ProviderType.java
+++ b/src/main/java/com/pet/domains/auth/oauth2/ProviderType.java
@@ -9,8 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProviderType {
     GOOGLE("google", new GoogleUser("sub", "email", "picture")),
-    NAVER("naver", new GoogleUser("nickname", "email", "profile_image")),
-    KAKAO("kakao", new GoogleUser("nickname", "email", "profile_image"));
+    NAVER("naver", new NaverUser("nickname", "email", "profile_image")),
+    KAKAO("kakao", new KakaoUser("nickname", "email", "profile_image"));
 
     private final String type;
 

--- a/src/test/java/com/pet/domains/account/WithAccountSecurityContextFactory.java
+++ b/src/test/java/com/pet/domains/account/WithAccountSecurityContextFactory.java
@@ -8,6 +8,7 @@ import com.pet.common.jwt.JwtAuthenticationToken;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.account.domain.Provider;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import com.pet.domains.auth.domain.Group;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -21,8 +22,9 @@ public class WithAccountSecurityContextFactory implements WithSecurityContextFac
 
     private static final String ROLE_USER = "ROLE_USER";
 
-    private final AccountService accountService;
     private final JwtAuthenticationProvider provider;
+
+    private final LoginService loginService;
 
     @Override
     public SecurityContext createSecurityContext(WithAccount withAccount) {
@@ -32,8 +34,8 @@ public class WithAccountSecurityContextFactory implements WithSecurityContextFac
         Group group = mock(Group.class);
         Account account = givenAccount(email, nickname, group);
 
-        given(accountService.login(email, password)).willReturn(account);
-        given(accountService.checkLoginAccountById(anyLong())).willReturn(account);
+        given(loginService.login(email, password)).willReturn(account);
+        given(loginService.checkLoginAccountById(anyLong())).willReturn(account);
         given(group.getAuthorities()).willReturn(List.of((GrantedAuthority)() -> ROLE_USER));
 
         SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/src/test/java/com/pet/domains/docs/BaseDocumentationTest.java
+++ b/src/test/java/com/pet/domains/docs/BaseDocumentationTest.java
@@ -7,6 +7,7 @@ import com.pet.common.property.JwtProperty;
 import com.pet.domains.account.controller.AccountController;
 import com.pet.domains.account.controller.NotificationController;
 import com.pet.domains.account.service.AccountService;
+import com.pet.domains.account.service.LoginService;
 import com.pet.domains.account.service.NotificationService;
 import com.pet.domains.animal.controller.AnimalController;
 import com.pet.domains.animal.service.AnimalService;
@@ -95,6 +96,9 @@ public abstract class BaseDocumentationTest {
 
     @MockBean
     protected CityService cityService;
+
+    @MockBean
+    protected LoginService loginService;
 
     protected JwtAuthentication getAuthenticationToken() {
         return (JwtAuthentication) SecurityContextHolder.getContext().getAuthentication().getPrincipal();


### PR DESCRIPTION
## PR 종류

- [ ] Feature
- [ ] Bug Fix
- [x] Refactoring
- [ ] Chore
- [ ] Init 

close #388 

## 내용
- 설명 : accountSerivce의 관련된 의존성을 낮추기 위해 AccountService와 LoginService로 분리하였습니다.
- Assertions Util 클래스를 만들어 예외처리를 하였습니다.

## 추가 및 변경 로직
- change

## 참고 및 기타
