### PR TITLE
[CP-390] feat: 이메일 인증 데이터 캐시로 관리

### DIFF
--- a/src/main/java/com/pet/Application.java
+++ b/src/main/java/com/pet/Application.java
@@ -12,7 +12,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Slf4j
-@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan("com.pet.common.property")

--- a/src/main/java/com/pet/common/config/AsyncConfig.java
+++ b/src/main/java/com/pet/common/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.pet.common.config;
+
+import com.querydsl.core.annotations.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Config
+public class AsyncConfig {
+
+    @Bean
+    public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);  // 쓰레드풀의 디폴드 갯수 (첫 요청이 들어온 순간 생성)
+        executor.setMaxPoolSize(20);  // 큐가 꽉찰 경우에 max 만큼 늘린다.
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("my thread");
+        executor.initialize();
+        return executor;
+    }
+
+}

--- a/src/main/java/com/pet/domains/account/domain/Email.java
+++ b/src/main/java/com/pet/domains/account/domain/Email.java
@@ -1,0 +1,50 @@
+package com.pet.domains.account.domain;
+
+import com.pet.common.exception.ExceptionMessage;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash("email")
+public class Email implements Serializable {
+
+    private static final Long EXPIRATION = 3L;
+
+    @Id
+    private String email;
+
+    private String verifyKey;
+
+    private boolean checked;
+
+    private LocalDateTime createdAt;
+
+    public Email(String email, String verifyKey) {
+        this.email = email;
+        this.verifyKey = verifyKey;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public boolean isVerifyTime(LocalDateTime requestTime) {
+        return this.createdAt.plusMinutes(EXPIRATION).isAfter(requestTime);
+    }
+
+    public void successVerified() {
+        this.checked = true;
+    }
+
+    public boolean isVerifyEmail(String email) {
+        if (StringUtils.equals(this.email, email) && checked) {
+            return true;
+        }
+        throw ExceptionMessage.INVALID_SIGN_UP.getException();
+    }
+
+    public boolean verify(String key) {
+        return verifyKey.equals(key);
+    }
+}

--- a/src/main/java/com/pet/domains/account/repository/EmailRepository.java
+++ b/src/main/java/com/pet/domains/account/repository/EmailRepository.java
@@ -1,0 +1,8 @@
+package com.pet.domains.account.repository;
+
+import com.pet.domains.account.domain.Email;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailRepository extends CrudRepository<Email, String> {
+
+}


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #390 

## 내용
- 설명 :
- spring data redis를 사용해서 기존 data jpa를 사용하는 것과 같은 방식으로 구현했습니다.
- 이메일 인증을 위한 이메일과 인증 번호는 휘발성 데이터라고 판단되어서 캐싱서버로 관리하는 것이 더 효율적이라고 생각되었습니다.
- 문제는 현재 로컬에서 redis와 커넥션 오류가 생겨 테스트를 해보지 못 했는데 로컬에서 테스트해볼 수 있는 방법이 있을까요?
- 추가적으로 redis 기능이 사용된다면 이메일 전송부분도 비동기처리로 변경하겠습니다~

## 추가 및 변경 로직
- change

## 참고 및 기타
