### PR TITLE
[CP-400] 리프레시 토큰을 이용한 엑세스 토큰 발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation 'ca.pjer:logback-awslogs-appender:1.4.0'
     implementation 'com.github.maricn:logback-slack-appender:1.4.0'
+    implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 
     implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.2.9'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.9'
@@ -78,6 +79,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation ('it.ozimov:embedded-redis:0.7.2') {
+        exclude module: 'junit'
+    }
 
 }
 

--- a/src/main/java/com/pet/common/config/SecurityConfig.java
+++ b/src/main/java/com/pet/common/config/SecurityConfig.java
@@ -11,7 +11,7 @@ import com.pet.common.jwt.JwtAuthenticationProvider;
 import com.pet.common.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
 import com.pet.common.oauth2.OAuth2AuthenticationSuccessHandler;
 import com.pet.common.property.JwtProperty;
-import com.pet.domains.account.service.AccountService;
+import com.pet.common.property.RefreshJwtProperty;
 import com.pet.domains.account.service.LoginService;
 import java.io.IOException;
 import java.util.Objects;
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
@@ -50,12 +51,23 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private static final String ROLE_ANONYMOUS = "ANONYMOUS";
 
     private final JwtProperty jwtProperty;
+    private final RefreshJwtProperty refreshJwtProperty;
 
     @Bean
     public Jwt jwt() {
         return new Jwt(
             jwtProperty.getIssuer(),
             jwtProperty.getClientSecret(),
+            jwtProperty.getExpirySeconds()
+        );
+    }
+
+    @Bean
+    @Qualifier("refresh")
+    public Jwt refreshJwt() {
+        return new Jwt(
+            refreshJwtProperty.getIssuer(),
+            refreshJwtProperty.getClientSecret(),
             jwtProperty.getExpirySeconds()
         );
     }

--- a/src/main/java/com/pet/common/property/RefreshJwtProperty.java
+++ b/src/main/java/com/pet/common/property/RefreshJwtProperty.java
@@ -1,0 +1,21 @@
+package com.pet.common.property;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "refresh")
+@Getter
+@RequiredArgsConstructor
+public class RefreshJwtProperty {
+
+    private final String header;
+
+    private final String issuer;
+
+    private final String clientSecret;
+
+    private final int expirySeconds;
+}

--- a/src/main/java/com/pet/domains/account/controller/AccountController.java
+++ b/src/main/java/com/pet/domains/account/controller/AccountController.java
@@ -1,7 +1,9 @@
 package com.pet.domains.account.controller;
 
+import com.pet.common.exception.ExceptionMessage;
 import com.pet.common.jwt.JwtAuthentication;
 import com.pet.common.response.ApiResponse;
+import com.pet.common.response.ErrorResponse;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.account.domain.LoginAccount;
 import com.pet.domains.account.dto.request.AccountAreaUpdateParam;
@@ -22,6 +24,7 @@ import com.pet.domains.auth.service.AuthenticationService;
 import com.pet.domains.post.service.MissingPostService;
 import com.pet.domains.post.service.ShelterPostService;
 import java.util.Map;
+import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -30,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -171,6 +175,15 @@ public class AccountController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAccount(@LoginAccount Account account) {
         accountService.deleteAccount(account);
+    }
+
+    @PostMapping("/refresh-token")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<AccountLoginResult> checkRefreshToken(String refreshToken) {
+        JwtAuthentication authentication = loginService.checkRefreshTokenAndGetAccessToken(refreshToken)
+            .map(account -> authenticationService.authenticate(account.getEmail(), account.getPassword()))
+            .orElseThrow(ExceptionMessage.INVALID_JWT::getException);
+        return ApiResponse.ok(AccountLoginResult.of(authentication.getAccountId(), authentication.getToken()));
     }
 
     private Cookie getCookie(String refreshToken) {

--- a/src/main/java/com/pet/domains/account/service/LoginService.java
+++ b/src/main/java/com/pet/domains/account/service/LoginService.java
@@ -1,5 +1,6 @@
 package com.pet.domains.account.service;
 
+import com.pet.common.jwt.Jwt;
 import com.pet.common.util.Random;
 import com.pet.domains.account.domain.Account;
 import com.pet.domains.account.domain.AccountGroup;
@@ -13,15 +14,20 @@ import com.pet.domains.account.repository.SignEmailRepository;
 import com.pet.domains.auth.domain.Group;
 import com.pet.domains.auth.oauth2.Oauth2User;
 import com.pet.domains.auth.oauth2.ProviderType;
+import com.pet.domains.auth.oauth2.RefreshToken;
 import com.pet.domains.auth.repository.GroupRepository;
+import com.pet.domains.auth.repository.RefreshTokenRepository;
 import com.pet.domains.image.domain.Image;
 import com.pet.infra.EmailMessage;
 import com.pet.infra.MailSender;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
@@ -45,6 +51,11 @@ public class LoginService {
     private final PasswordEncoder passwordEncoder;
 
     private final EmailRepository emailRepository;
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Qualifier("refresh")
+    private final Jwt refreshJwt;
 
     @Transactional
     public void sendEmail(String email) {
@@ -133,6 +144,12 @@ public class LoginService {
                     .provider(Provider.findByType(provider))
                     .profileImage(new Image(profileImage)).group(group).build());
             });
+    }
+
+    public String createRefreshToken(Long accountId, String email) {
+        String refreshToken = refreshJwt.sign(Jwt.Claims.from(accountId, new String[] {"ROLE_USER"}));
+        refreshTokenRepository.save(RefreshToken.builder().email(email).token(refreshToken).build());
+        return refreshToken;
     }
 
 }

--- a/src/main/java/com/pet/domains/account/service/LoginService.java
+++ b/src/main/java/com/pet/domains/account/service/LoginService.java
@@ -8,6 +8,7 @@ import com.pet.domains.account.domain.Email;
 import com.pet.domains.account.domain.Provider;
 import com.pet.domains.account.domain.SignEmail;
 import com.pet.domains.account.dto.request.AccountSignUpParam;
+import com.pet.domains.account.dto.response.AccountLoginResult;
 import com.pet.domains.account.repository.AccountRepository;
 import com.pet.domains.account.repository.EmailRepository;
 import com.pet.domains.account.repository.SignEmailRepository;
@@ -22,6 +23,7 @@ import com.pet.infra.EmailMessage;
 import com.pet.infra.MailSender;
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -152,4 +154,9 @@ public class LoginService {
         return refreshToken;
     }
 
+    public Optional<Account> checkRefreshTokenAndGetAccessToken(String refreshToken) {
+        return refreshTokenRepository.findById(refreshToken)
+            .map(token -> accountRepository.findByEmail(token.getEmail()))
+            .orElseThrow(NullPointerException::new);
+    }
 }

--- a/src/main/java/com/pet/domains/auth/oauth2/RefreshToken.java
+++ b/src/main/java/com/pet/domains/auth/oauth2/RefreshToken.java
@@ -2,10 +2,12 @@ package com.pet.domains.auth.oauth2;
 
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
 @RedisHash("refreshToken")
+@Getter
 public class RefreshToken {
 
     @Id

--- a/src/main/java/com/pet/domains/auth/oauth2/RefreshToken.java
+++ b/src/main/java/com/pet/domains/auth/oauth2/RefreshToken.java
@@ -1,0 +1,28 @@
+package com.pet.domains.auth.oauth2;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash("refreshToken")
+public class RefreshToken {
+
+    @Id
+    private String token;
+
+    private String email;
+
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RefreshToken(String token, String email) {
+        this.token = token;
+        this.email = email;
+        createdAt = LocalDateTime.now();
+    }
+
+    public boolean isVerify() {
+        return createdAt.isAfter(LocalDateTime.now().plusDays(30));
+    }
+}

--- a/src/main/java/com/pet/domains/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/pet/domains/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.pet.domains.auth.repository;
+
+import com.pet.domains.auth.oauth2.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -114,4 +114,10 @@ jwt:
   header: ${AUTHORIZATION:default}
   issuer: ${ISSUER:default}
   client-secret: ${CLIENT_SECRET:default}
-  expiry-seconds: ${EXPIRY_SECONDS:600}
+  expiry-seconds: 1200
+
+refresh:
+  header: ${AUTHORIZATION:default}
+  issuer: ${ISSUER:default}
+  client-secret: ${CLIENT_SECRET:default}
+  expiry-seconds: 43200

--- a/src/test/java/com/pet/domains/docs/BaseDocumentationTest.java
+++ b/src/test/java/com/pet/domains/docs/BaseDocumentationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pet.common.config.SecurityConfig;
 import com.pet.common.jwt.JwtAuthentication;
 import com.pet.common.property.JwtProperty;
+import com.pet.common.property.RefreshJwtProperty;
 import com.pet.domains.account.controller.AccountController;
 import com.pet.domains.account.controller.NotificationController;
 import com.pet.domains.account.service.AccountService;
@@ -28,6 +29,7 @@ import com.pet.domains.statistics.controller.PostStatisticsController;
 import com.pet.domains.statistics.service.PostStatisticsService;
 import org.junit.jupiter.api.Disabled;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -49,9 +51,10 @@ import org.springframework.test.web.servlet.MockMvc;
     PostStatisticsController.class},
     includeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
-    })
+    }
+)
 @AutoConfigureRestDocs
-@EnableConfigurationProperties(value = JwtProperty.class)
+@EnableConfigurationProperties(value = {JwtProperty.class, RefreshJwtProperty.class})
 @Disabled
 public abstract class BaseDocumentationTest {
 


### PR DESCRIPTION
## PR 종류

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Chore
- [ ] Init 

close #399 

## 내용
- 설명 : refresh 토큰을 캐시서버에 담아두고 조회합니다. 

리프레시 토큰을 기반으로 하는 인증 flow는 다음과 같습니다.

로그인, 회원 가입시 -> access token, refresh token 발급

엑세스 토큰 만료시 리프레시 토큰 서버로 전송 -> 유효하다면 새롭게 엑세스 토큰 발급

리프레시 토큰도 만료가 된다면 재로그인 필요

엑세스 토큰 만료시간 : 2시간
리프레시 토큰 만료시간 : 30일

## 추가 및 변경 로직
- change

## 참고 및 기타
